### PR TITLE
Improved: Expansion of form widget field disabled atrribute with xsd improvement

### DIFF
--- a/ebaystore/widget/EbaySellingManagerForms.xml
+++ b/ebaystore/widget/EbaySellingManagerForms.xml
@@ -99,12 +99,12 @@ under the License.
     <form name="OpenUnpaid" type="single" target="addDispute">
         <field name="productStoreId"><hidden value="${parameters.productStoreId}"/></field>
         <field name="itemId"><hidden value="${parameters.itemId}"/></field>
-        <field name="item"><text disabled="true" default-value="${parameters.itemId} - ${parameters.title}"/></field>
-        <field name="listingType"><text disabled="true" default-value="${parameters.listingType}"/></field>
-        <field name="quantity"><text disabled="true" default-value="${parameters.quantity}"/></field>
-        <field name="salePrice"><text disabled="true" default-value="${parameters.salePrice}"/></field>
+        <field name="item" disabled="true"><text default-value="${parameters.itemId} - ${parameters.title}"/></field>
+        <field name="listingType" disabled="true"><text default-value="${parameters.listingType}"/></field>
+        <field name="quantity" disabled="true"><text default-value="${parameters.quantity}"/></field>
+        <field name="salePrice" disabled="true"><text default-value="${parameters.salePrice}"/></field>
         <field name="transactionId"><hidden value="${parameters.transactionId}"/></field>
-        <field name="transaction"><text disabled="true" default-value="${parameters.transactionId}"/></field>
+        <field name="transaction" disabled="true"><text default-value="${parameters.transactionId}"/></field>
         <field name="disputeReasonCodeType">
             <radio no-current-selected-key="TransactionMutuallyCanceled">
                 <option key="BUYER_HAS_NOT_PAID" description="The buyer has not paid for the item"/>

--- a/example/config/ExampleUiLabels.xml
+++ b/example/config/ExampleUiLabels.xml
@@ -329,6 +329,12 @@
         <value xml:lang="zh">相互依赖的下拉框</value>
         <value xml:lang="zh-TW">相互依賴的下拉清單</value>
     </property>
+    <property key="ExampleDisabledFields">
+        <value xml:lang="en">Disabled Fields</value>
+    </property>
+    <property key="ExampleDisabledFieldDescription">
+        <value xml:lang="en">Here is a simple example for all the fields with disabled attributes</value>
+    </property>
     <property key="ExampleDropDown">
         <value xml:lang="en">drop-down</value>
         <value xml:lang="fr">liste déroulante</value>

--- a/example/widget/example/FormWidgetExampleForms.xml
+++ b/example/widget/example/FormWidgetExampleForms.xml
@@ -452,4 +452,33 @@ under the License.
     <form name="MaskFieldExampleForm" type="single">
         <field name="maskField" title="${uiLabelMap.ExampleField}"><text mask='a*-999-a999'/></field>
     </form>
+
+    <form name="DisabledFieldExampleForm" type="single">
+        <field name="textField" title="Text Field" disabled="true"><text/></field>
+        <field name="checkField" title="Check Field" disabled="true">
+            <check>
+                <entity-options key-field-name="exampleTypeId" entity-name="ExampleType"/>
+            </check>
+        </field>
+        <field name="dropdownField" title="Dropdown Field" disabled="true">
+            <drop-down allow-empty="true">
+                <option key="Y" description="${uiLabelMap.CommonY}"/>
+                <option key="N" description="${uiLabelMap.CommonN}"/>
+            </drop-down>
+        </field>
+        <field name="radioField" title="Radio Field" disabled="true">
+            <radio>
+                <option key="N" description="${uiLabelMap.CommonNone}"/>
+                <option key="P" description="${uiLabelMap.PartyPostal}"/>
+                <option key="T" description="${uiLabelMap.PartyTelecom}"/>
+                <option key="O" description="${uiLabelMap.CommonOther}"/>
+            </radio>
+        </field>
+        <field name="dateTimeField" title="Datetime Field" disabled="true">
+            <date-time default-value="${nowTimestamp}"/>
+        </field>
+        <field name="textAreaField" title="Textarea Field" disabled="true">
+            <textarea rows="10" default-value="This is a disabled text area field"/>
+        </field>
+    </form>
 </forms>

--- a/example/widget/example/FormWidgetExampleScreens.xml
+++ b/example/widget/example/FormWidgetExampleScreens.xml
@@ -138,6 +138,13 @@ under the License.
                                     </container>
                                     <include-form name="MaskFieldExampleForm" location="component://example/widget/example/FormWidgetExampleForms.xml"/>
                                 </container>
+                                <container style="screenlet-body">
+                                    <container style="button-bar"><label style="h2">${uiLabelMap.ExampleDisabledFields}</label></container>
+                                    <container style="screenlet-body">
+                                        <label>${uiLabelMap.ExampleDisabledFieldDescription}</label>
+                                    </container>
+                                    <include-form name="DisabledFieldExampleForm" location="component://example/widget/example/FormWidgetExampleForms.xml"/>
+                                </container>
                             </widgets>
                             <fail-widgets>
                                 <label style="h3">${uiLabelMap.ExampleViewPermissionError}</label>

--- a/scrum/widget/CommunicationEventForms.xml
+++ b/scrum/widget/CommunicationEventForms.xml
@@ -185,7 +185,7 @@ under the License.
         </field>
     </form>
     <form name="ViewEmailForProduct" type="single" extends="EditEmail" target="${target}" default-map-name="communicationEvent" id="updateEmailForProduct">
-        <field name="subject"><text size="74"  maxlength="255" disabled="true"/> </field>
+        <field name="subject" disabled="true"><text size="74"  maxlength="255"/> </field>
         <field name="content"><textarea cols="72" rows="15" read-only="true"/> </field>
     </form>
     <form name="ListCommContentForProduct" type="list" extends="ListCommContent" list-name="contentDataResourceList" paginate-target="/ListCommContent" target="removeAttachFileForProduct"

--- a/scrum/widget/TaskForms.xml
+++ b/scrum/widget/TaskForms.xml
@@ -66,7 +66,7 @@
         <field name="sprintId"><hidden value="${parameters.sprintId}"/></field>
         <field name="workEffortId" use-when="task!=null"><hidden value="${parameters.taskId}"/></field>
         <field name="taskId" use-when="task!=null"><hidden value="${parameters.taskId}"/></field>
-        <field name="id" use-when="task!=null" title="Task Id"><text default-value="${parameters.taskId}" disabled="true"/></field>
+        <field name="id" use-when="task!=null" title="Task Id" disabled="true"><text default-value="${parameters.taskId}"/></field>
         <field name="workEffortName" title="${uiLabelMap.ScrumTaskName}" required-field="true" tooltip="${uiLabelMap.ScrumToolTip100CharsMaximun}"><text/></field>
         <field name="workEffortTypeId" title="${uiLabelMap.ScrumTaskType}" required-field="true">
             <drop-down>
@@ -89,7 +89,7 @@
             </display-entity>
         </field>
         <field name="planHours" title="${uiLabelMap.ScrumPlannedHours}"><text size="3" default-value="${resultMap.planHours}"/></field>
-        <field name="actualHours" use-when="task!=null" title="${uiLabelMap.ScrumActualHours}"><text default-value="${results.actualHours}" size="3" disabled="true"/></field>
+        <field name="actualHours" use-when="task!=null" title="${uiLabelMap.ScrumActualHours}" disabled="true"><text default-value="${results.actualHours}" size="3"/></field>
         <!--<field name="actualHours" use-when="task==null" title="Actual Hours"><text size="3"/></field>-->
         <field name="currentStatusId" use-when="task==null"><hidden value="STS_CREATED"/></field>
         <field name="description" title="${uiLabelMap.CommonDescription}" tooltip="${uiLabelMap.CommonMax250Chars}"><textarea/></field>
@@ -448,7 +448,7 @@
         <alt-target use-when="task==null" target="createTask"/>
         <field name="projectId" use-when="task!=null&amp;&amp;project!=null"><display description="${project.workEffortName}"/></field>
         <field name="taskId"><hidden value="${parameters.taskId}"/></field>
-        <field name="id" use-when="task!=null" title="Task Id"><text default-value="${parameters.taskId}" disabled="true"/></field>
+        <field name="id" use-when="task!=null" title="Task Id" disabled="true"><text default-value="${parameters.taskId}"/></field>
         <field name="workEffortName" title="${uiLabelMap.ScrumTaskName}" required-field="true"><text size="60"/></field>
         <field name="workEffortId"><hidden value="${parameters.taskId}"/></field>
         <field name="workEffortTypeId" title="${uiLabelMap.ScrumTaskType}" required-field="true">
@@ -495,7 +495,7 @@
             </display-entity>
         </field>
         <field name="planHours" title="${uiLabelMap.ScrumPlanHours}"><text size="3" default-value="${resultMap.planHours}"/></field>
-        <field name="actualHours" use-when="task!=null" title="${uiLabelMap.ScrumActualHours}"><text default-value="${results.actualHours}" size="3" disabled="true"/></field>
+        <field name="actualHours" use-when="task!=null" title="${uiLabelMap.ScrumActualHours}" disabled="true"><text default-value="${results.actualHours}" size="3"/></field>
         <field name="currentStatusId"  use-when="task==null"><hidden value="STS_CREATED"/></field>
         <field name="uploadedFile" use-when="task==null"><file/></field>
         <field name="contentTypeId" use-when="task==null"><hidden value="DOCUMENT"/></field>


### PR DESCRIPTION
Improved: Expansion of form widget field disabled atrribute with xsd improvement

(OFBIZ-10432)

Added disabled attribute support in ModelFormField with xs: boolean type
Removed specific field level disabled attribute support for CheckField and TextField
Modified existing usage of the disabled attribute as per new implementation.
Added new DisabledFieldExampleForm under Form Widget Examples for all the fields with disabled attributes.

Thanks: Rishi for the report and Taher, Gil and Jacques for the feedback