### PR TITLE
Fixed: Product summary cards don't have uniform height. (OFBIZ-11910)

### DIFF
--- a/ecommerce/template/catalog/ProductSummary.ftl
+++ b/ecommerce/template/catalog/ProductSummary.ftl
@@ -72,7 +72,7 @@ ${variantInfoJavaScript!}
               <#assign productDetailId = "productDetailId"/>
               <#assign productDetailId = productDetailId + product.productId/>
 
-              <div class="col-md-4 products-card">
+              <div class="col-md-4 products-card card-deck">
                 <div class="card text-center">
                   <a href="${productUrl}" class="mt-2">
                     <img class="card-img-top" src="<@ofbizContentUrl>${contentPathPrefix!}${smallImageUrl}</@ofbizContentUrl>" alt="Small Image">


### PR DESCRIPTION
Fixed: Product summary cards don't have a uniform height.
Done following:
1. Used bootstrap card-deck to equalize the height/width of all the product summary cards.

Reference:
https://v4-alpha.getbootstrap.com/components/card/#card-decks

