### PR TITLE
Updated lucene and solr dependecy to fix the test case failure relate…

### DIFF
--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 dependencies {
-    pluginLibsCompile 'org.apache.lucene:lucene-core:7.1.0'
-    pluginLibsCompile 'org.apache.lucene:lucene-queryparser:7.1.0'
-    pluginLibsCompile 'org.apache.lucene:lucene-analyzers-common:7.1.0'
+    pluginLibsCompile 'org.apache.lucene:lucene-core:8.5.2'
+    pluginLibsCompile 'org.apache.lucene:lucene-queryparser:8.5.2'
+    pluginLibsCompile 'org.apache.lucene:lucene-analyzers-common:8.5.2'
 }

--- a/lucene/src/main/java/org/apache/ofbiz/content/search/SearchWorker.java
+++ b/lucene/src/main/java/org/apache/ofbiz/content/search/SearchWorker.java
@@ -41,7 +41,7 @@ public final class SearchWorker {
 
     public static final String module = SearchWorker.class.getName();
 
-    private static final Version LUCENE_VERSION = Version.LUCENE_7_1_0;
+    private static final Version LUCENE_VERSION = Version.LUCENE_8_5_2;
 
     private SearchWorker() {}
 

--- a/lucene/src/main/java/org/apache/ofbiz/content/test/LuceneTests.java
+++ b/lucene/src/main/java/org/apache/ofbiz/content/test/LuceneTests.java
@@ -95,7 +95,7 @@ public class LuceneTests extends OFBizTestCase {
         combQueryBuilder.add(query, BooleanClause.Occur.MUST);
         BooleanQuery combQuery = combQueryBuilder.build();
 
-        TopScoreDocCollector collector = TopScoreDocCollector.create(10);
+        TopScoreDocCollector collector = TopScoreDocCollector.create(10, 10);
         searcher.search(combQuery, collector);
 
         assertEquals("Only 1 result expected from the testdata", 1, collector.getTotalHits());

--- a/solr/build.gradle
+++ b/solr/build.gradle
@@ -17,14 +17,16 @@
  * under the License.
  */
 dependencies {
-    pluginLibsCompile 'org.apache.solr:solr-core:7.1.0'
-    pluginLibsCompile 'com.google.guava:guava:20.0'
+    // Remember to change the version number in SearchWorker class when upgrading.
+    // Also Solr et Lucene should use the same version, luceneMatchVersion should be updated in solrconfig.xml
+    pluginLibsCompile 'org.apache.solr:solr-core:8.5.2'
+    pluginLibsCompile 'com.google.guava:guava:28.0-jre'
 }
 
 configurations.all {
     resolutionStrategy {
       dependencySubstitution {
-          substitute module('com.google.guava:guava') with module('com.google.guava:guava:20.0')
+          substitute module('com.google.guava:guava') with module('com.google.guava:guava:28.0-jre')
       }
     }
 }

--- a/solr/home/solrdefault/conf/solrconfig.xml
+++ b/solr/home/solrdefault/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.6.0</luceneMatchVersion>
+  <luceneMatchVersion>8.5.2</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in


### PR DESCRIPTION
Fixed: Updated lucene and solr dependecy to fix the test case failure relate…d to tika-parser dependency update
(OFBIZ-12100)

Explanation
Backported lucene and solr dependency update to release 17.12. 

