### PR TITLE
Fixed: Fitering on StatusId in FindTask does not work

### DIFF
--- a/projectmgr/widget/forms/TaskForms.xml
+++ b/projectmgr/widget/forms/TaskForms.xml
@@ -198,7 +198,6 @@
             </service>
             <set field="plannedHours" from-field="result.taskInfo.plannedHours"/>
             <set field="actualHours" from-field="result.taskInfo.actualHours"/>
-            <set field="currentStatusId" from-field="result.taskInfo.currentStatusId"/>
         </row-actions>
         <field name="workEffortId" title="${uiLabelMap.ProjectMgrTaskId}" widget-style="buttontext">
             <hyperlink description="${workEffortName}" target="taskView" also-hidden="false">


### PR DESCRIPTION
Fixed: Fitering on StatusId in FindTask does not work
(OFBIZ-10914)

As per implementation getProjectTask service is used to get the task status, it returned manipulated status for display based on some condition. Ideally list task should show the actual status set on the entity rather manipulated status.

Thanks Pierre Smits for reporting the issue.