### PR TITLE
Improved: Switch from jCenter to mavenCentral to handle the jCenter shutdown r18.12 (OFBIZ-12171)

### DIFF
--- a/ldap/build.gradle
+++ b/ldap/build.gradle
@@ -18,5 +18,5 @@
  */
 
 dependencies {
-    pluginLibsCompile 'org.jasig.cas:cas-server-core:3.3.5'
+    pluginLibsCompile 'org.apereo.cas:cas-server-support-ldap-core:5.0.10'
 }

--- a/ldap/src/main/java/org/apache/ofbiz/ldap/activedirectory/OFBizActiveDirectoryAuthenticationHandler.java
+++ b/ldap/src/main/java/org/apache/ofbiz/ldap/activedirectory/OFBizActiveDirectoryAuthenticationHandler.java
@@ -29,9 +29,10 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
-import org.jasig.cas.util.LdapUtils;
 import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.ldap.commons.AbstractOFBizAuthenticationHandler;
+import org.apereo.cas.util.LdapUtils;
+import org.ldaptive.LdapEntry;
 import org.w3c.dom.Element;
 
 
@@ -91,7 +92,8 @@ public final class OFBizActiveDirectoryAuthenticationHandler extends AbstractOFB
             }
             String filter = UtilXml.childElementValue(rootElement, "Filter", "(objectclass=*)");
             String attribute = UtilXml.childElementValue(rootElement, "Attribute", "uid=%u");
-            attribute = LdapUtils.getFilterWithValues(attribute, username);
+            LdapEntry entry = new LdapEntry(username);
+            attribute = LdapUtils.getString(entry, attribute);
             NamingEnumeration<SearchResult> answer = ctx.search(baseDN,
                     // Filter expression
                     "(&(" + filter + ") (" + attribute +"))",

--- a/ldap/src/main/java/org/apache/ofbiz/ldap/openldap/OFBizLdapAuthenticationHandler.java
+++ b/ldap/src/main/java/org/apache/ofbiz/ldap/openldap/OFBizLdapAuthenticationHandler.java
@@ -27,7 +27,8 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
-import org.jasig.cas.util.LdapUtils;
+import org.apereo.cas.util.LdapUtils;
+import org.ldaptive.LdapEntry;
 import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.ldap.commons.AbstractOFBizAuthenticationHandler;
 import org.w3c.dom.Element;
@@ -76,7 +77,8 @@ public final class OFBizLdapAuthenticationHandler extends AbstractOFBizAuthentic
             }
             String filter = UtilXml.childElementValue(rootElement, "Filter", "(objectclass=*)");
             String attribute = UtilXml.childElementValue(rootElement, "Attribute", "uid=%u");
-            attribute = LdapUtils.getFilterWithValues(attribute, username);
+            LdapEntry entry = new LdapEntry(username);
+            attribute = LdapUtils.getString(entry, attribute);
             NamingEnumeration<SearchResult> answer = ctx.search(baseDN,
                     // Filter expression
                     "(&(" + filter + ") (" + attribute +"))",


### PR DESCRIPTION
jCenter migration for the 18.12 release branch. Must be applied together with the corresponding changes in framework.