### PR TITLE
Replace label 'Summary' by a label from CommonSummary

### DIFF
--- a/ecommerce/template/cart/ShowCart.ftl
+++ b/ecommerce/template/cart/ShowCart.ftl
@@ -460,7 +460,7 @@ under the License.
           <tfoot>
             <tr class="thead-light">
               <th colspan="8">
-                Summary:
+                ${uiLabelMap.CommonSummary}:
               </th>
             </tr>
             <#if shoppingCart.getAdjustments()?has_content>


### PR DESCRIPTION
Fixed: label from CommonUiLabels file instead of manual label
