### PR TITLE
Add test on catalogQuickaddUse because it can be null

### DIFF
--- a/ecommerce/template/includes/Header.ftl
+++ b/ecommerce/template/includes/Header.ftl
@@ -120,7 +120,7 @@ $(document).ready(function() {
           <a class="nav-link" href="<@ofbizUrl>orderhistory</@ofbizUrl>">${uiLabelMap.EcommerceOrderHistory}</a>
         </li>
       </#if>
-      <#if catalogQuickaddUse>
+      <#if catalogQuickaddUse??>
         <li class="nav-item"><a class="nav-link" href="<@ofbizUrl>quickadd</@ofbizUrl>">${uiLabelMap.CommonQuickAdd}</a></li>
       </#if>
     </ul>


### PR DESCRIPTION
Fixed: if there is no quick add category configured, catalogQuickaddUse is null and ftl produce an error in this case