### PR TITLE
Fixed: REST-API Plugin: Remove errors and warnings in generated openapi documentation (OFBIZ-12426)

### DIFF
--- a/rest-api/src/main/java/org/apache/ofbiz/ws/rs/openapi/OFBizOpenApiReader.java
+++ b/rest-api/src/main/java/org/apache/ofbiz/ws/rs/openapi/OFBizOpenApiReader.java
@@ -141,7 +141,6 @@ public final class OFBizOpenApiReader extends Reader implements OpenApiReader {
                         serviceInParam.content(new Content().addMediaType(javax.ws.rs.core.MediaType.APPLICATION_JSON,
                                 new MediaType().schema(refSchema)));
                         operation.addParametersItem(serviceInParam);
-                        operation.addParametersItem(HEADER_ACCEPT_JSON);
                     } else if (verb.matches(HttpMethod.POST + "|" + HttpMethod.PUT + "|" + HttpMethod.PATCH)) {
                         RequestBody request = new RequestBody()
                                 .description("Request Body for operation " + op.getDescription())
@@ -158,7 +157,8 @@ public final class OFBizOpenApiReader extends Reader implements OpenApiReader {
                                 .findFirst().orElse(null);
                         final PathParameter pathParameter = (PathParameter) new PathParameter().required(true)
                                 .description(mdParam != null ? mdParam.getShortDisplayDescription() : "")
-                                .name(pathParam);
+                                .name(pathParam)
+                                .schema(OpenApiUtil.getAttributeSchema(service, mdParam));
                         operation.addParametersItem(pathParameter);
                     }
                     addServiceOutSchema(service);

--- a/rest-api/src/main/java/org/apache/ofbiz/ws/rs/util/OpenApiUtil.java
+++ b/rest-api/src/main/java/org/apache/ofbiz/ws/rs/util/OpenApiUtil.java
@@ -160,7 +160,7 @@ public final class OpenApiUtil {
     private static void buildApiResponseSchemas() {
         Schema<?> genericErrorSchema = new MapSchema().addProperties("statusCode", new IntegerSchema().description("HTTP Status Code"))
                  .addProperties("statusDescription", new StringSchema().description("HTTP Status Code Description"))
-                 .addProperties("errorTyoe", new StringSchema().description("Error Type for the error"))
+                 .addProperties("errorType", new StringSchema().description("Error Type for the error"))
                  .addProperties("errorMessage", new StringSchema().description("Error Message"));
         SCHEMAS.put("api.response.unauthorized.noheader", genericErrorSchema);
         SCHEMAS.put("api.response.unauthorized.invalidtoken", genericErrorSchema);
@@ -203,7 +203,7 @@ public final class OpenApiUtil {
                 "errorMessage", "HTTP POST is not allowed on service 'demoDoGetService'.");
 
         final ApiResponse unauthorizedNoHeader = new ApiResponse().addHeaderObject(HttpHeaders.WWW_AUTHENTICATE, new Header()
-                .example(HttpHeaders.WWW_AUTHENTICATE + ": "
+                .schema(new Schema<>().type("string").format("string")).example(HttpHeaders.WWW_AUTHENTICATE + ": "
                  + AuthenticationScheme.BEARER.getScheme() + " realm=\"" + AuthenticationScheme.REALM + "\""))
                 .description("Unauthorized: Access is denied due to invalid or absent Authorization header.")
                 .content(new Content()
@@ -221,6 +221,7 @@ public final class OpenApiUtil {
                                 .example(unauthorizedInvalidTokenExample)));
 
         final ApiResponse forbidden = new ApiResponse().addHeaderObject(HttpHeaders.WWW_AUTHENTICATE, new Header()
+                .schema(new Schema<>().type("string"))
                 .example(HttpHeaders.WWW_AUTHENTICATE + ": "
                 + AuthenticationScheme.BEARER.getScheme() + " realm=\"" + AuthenticationScheme.REALM + "\""))
                 .description("Forbidden: Insufficient rights to perform this API call.")
@@ -244,6 +245,7 @@ public final class OpenApiUtil {
                                 .schema(new Schema<>()
                                         .$ref("#/components/schemas/" + "api.response.service.unprocessableentity"))
                                 .example(unprocessableEntExample)));
+        
         final ApiResponse methodNotAllowed = new ApiResponse()
                 .description("Method Not Allowed: Service called with HTTP method other than the declared one.")
                 .content(new Content()
@@ -287,7 +289,7 @@ public final class OpenApiUtil {
         return parentSchema;
     }
 
-    private static Schema<?> getAttributeSchema(ModelService service, ModelParam param) {
+    public static Schema<?> getAttributeSchema(ModelService service, ModelParam param) {
         Schema<?> schema = null;
         Class<?> schemaClass = getOpenApiTypeForAttributeType(param.getType());
         if (schemaClass == null) {


### PR DESCRIPTION
This fixes the following errors and warnings which are displayed by the
Swagger Editor (editor.swagger.io) when reading the generated openapi
documentation:

Errors fixed
* "Header parameters named "Authorization" are ignored. Use the
`securitySchemes` and `security` sections instead to define
authorization."
* "Structural error at paths./....parameters.0 should have either a
`schema` or `content` property"
the generated parameters from the service definition now have schema
entries generated
* the same applies to the WWW-Authenticate header in the responses

Warnings fixed

* "Header parameters named "Accept" are ignored. The values for the
"Accept" header are defined by `responses.<code>.content.<media-type>`."
