### PR TITLE
Fixed: AssetMaint not accessible by user with 'VIEW' permission (OFBIZ-12485)

### DIFF
--- a/assetmaint/data/AssetMaintSecurityGroupDemoData.xml
+++ b/assetmaint/data/AssetMaintSecurityGroupDemoData.xml
@@ -28,4 +28,5 @@ under the License.
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="ASSETMAINTTECH" permissionId="ASSETMAINT_UPDATE"/>
 
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="FULLADMIN" permissionId="ASSETMAINT_ADMIN"/>
+    <SecurityGroupPermission fromDate="2001-01-01 00:00:00.0" groupId="VIEWADMIN" permissionId="ASSETMAINT_VIEW"/>
 </entity-engine-xml>


### PR DESCRIPTION
Currently the AssetMaint application is not accessible by a user with the VIEW permission, as demonstrated with userLoginId = 'auditor'.

Modfied: AssetMaintSecurityGroupDemoData.xml: added SecurityGroupPermission record