### PR TITLE
Improved: Project - MainActionMenu (OFBIZ-12484)

### DIFF
--- a/projectmgr/widget/CommonScreens.xml
+++ b/projectmgr/widget/CommonScreens.xml
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
     <screen name="main-decorator">
@@ -31,15 +30,8 @@ under the License.
                 <property-map resource="HumanResUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="EcommerceUiLabels" map-name="uiLabelMap" global="true"/>
-
-                <!-- The two default (global) stylesheets are added to the list
-                     of stylesheets to the first and second position -->
-
                 <set field="layoutSettings.companyName" from-field="uiLabelMap.ProjectMgrCompanyName" global="true"/>
                 <set field="layoutSettings.companySubtitle" from-field="uiLabelMap.ProjectMgrCompanySubtitle" global="true"/>
-                <!-- layoutSettings.headerImageUrl can be used to specify an application specific logo; if not set,
-                     then the global layoutSettings.commonHeaderImageUrl (specified in GlobalDecorator) will be used. -->
-                <!--<set field="layoutSettings.headerImageUrl" value="/images/ofbiz_logo.png" global="true"/>-->
                 <set field="layoutSettings.styleSheets[]" value="/projectmgr/static/projectmgr.css" global="true"/>
                 <set field="activeApp" value="projectmgr" global="true"/>
                 <set field="applicationMenuName" value="ProjectMgrAppBar" global="true"/>
@@ -66,6 +58,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -74,7 +67,9 @@ under the License.
                                 </and>
                             </condition>
                             <widgets>
+                                <label style="h1" text="${uiLabelMap.Project}: ${project.workEffortId}"/>
                                 <include-menu name="ProjectTabBar" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                                <include-menu name="ProjectButtonBar" location="component://projectmgr/widget/ProjectMenus.xml"/>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -91,12 +86,8 @@ under the License.
                                         </not>
                                     </condition>
                                     <widgets>
-                                        <include-menu name="ProjectButtonBar" location="component://projectmgr/widget/ProjectMenus.xml"/>
-                                        <container style="clear"/>
-                                        <label style="h1" text="${uiLabelMap.ProjectMgrProjectCurrent}: ${project.workEffortName}[${project.workEffortId}]"/>
                                     </widgets>
                                  </section>
-
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>
@@ -118,6 +109,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -126,7 +118,9 @@ under the License.
                                 </and>
                             </condition>
                             <widgets>
+                                <label style="h1" text="${uiLabelMap.WorkEffortTask}: ${workEffort.workEffortId}"/>
                                 <include-menu name="TaskTabBar" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                                <include-menu name="TaskSubTabBar" location="component://projectmgr/widget/ProjectMenus.xml"/>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -136,21 +130,6 @@ under the License.
                                 <if-has-permission permission="PROJECTMGR" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <section>
-                                    <condition>
-                                        <not><if-empty field="workEffort"/></not>
-                                    </condition>
-                                    <widgets>
-                                        <include-menu name="TaskSubTabBar" location="component://projectmgr/widget/ProjectMenus.xml"/>
-                                        <container style="clear"/>
-                                        <label style="h1" text="${uiLabelMap.ProjectMgrTaskCurrent}: ${workEffort.workEffortName} [${workEffort.workEffortId}]"/>
-                                        <label style="h1" text="${uiLabelMap.ProjectMgrPhaseName}: ${phaseName}"/>
-                                        <container style="h1">
-                                            <label text="${uiLabelMap.ProjectMgrProjectName}: ${projectName}"/>
-                                            <link text="[${projectId}]" target="projectView"><parameter param-name="projectId"/></link>
-                                        </container>
-                                    </widgets>
-                                </section>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>
@@ -170,6 +149,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -195,6 +177,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for PartyAbility, _VIEW permission -->
@@ -226,6 +211,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -289,6 +277,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -366,7 +357,6 @@ under the License.
                                                     <label style="h1" text="${uiLabelMap.PartyNewUser}"/>
                                                 </fail-widgets>
                                             </section>
-
                                             <label style="h1" text="[${partyId}]"/>
                                         </container>
                                     </widgets>
@@ -386,6 +376,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="CommonRequestDecorator" location="component://order/widget/ordermgr/CommonScreens.xml">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-section-include name="body"/>
                     </decorator-section>
@@ -393,7 +386,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="GlobalHRSettingsDecorator">
         <section>
             <actions>
@@ -401,6 +393,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://projectmgr/widget/ProjectMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-section-include name="body"/>
                     </decorator-section>
@@ -408,5 +403,4 @@ under the License.
             </widgets>
         </section>
     </screen>
-
 </screens>

--- a/projectmgr/widget/CommonScreens.xml
+++ b/projectmgr/widget/CommonScreens.xml
@@ -30,8 +30,15 @@ under the License.
                 <property-map resource="HumanResUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="EcommerceUiLabels" map-name="uiLabelMap" global="true"/>
+
+                    <!-- The two default (global) stylesheets are added to the list
+                     of stylesheets to the first and second position -->
+                    
                 <set field="layoutSettings.companyName" from-field="uiLabelMap.ProjectMgrCompanyName" global="true"/>
                 <set field="layoutSettings.companySubtitle" from-field="uiLabelMap.ProjectMgrCompanySubtitle" global="true"/>
+                <!-- layoutSettings.headerImageUrl can be used to specify an application specific logo; if not set,
+                     then the global layoutSettings.commonHeaderImageUrl (specified in GlobalDecorator) will be used. -->
+                <!--<set field="layoutSettings.headerImageUrl" value="/images/ofbiz_logo.png" global="true"/>-->                    
                 <set field="layoutSettings.styleSheets[]" value="/projectmgr/static/projectmgr.css" global="true"/>
                 <set field="activeApp" value="projectmgr" global="true"/>
                 <set field="applicationMenuName" value="ProjectMgrAppBar" global="true"/>

--- a/projectmgr/widget/ProjectMenus.xml
+++ b/projectmgr/widget/ProjectMenus.xml
@@ -17,14 +17,12 @@
     specific language governing permissions and limitations
     under the License.
 -->
-
 <menus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns="http://ofbiz.apache.org/Widget-Menu" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Menu http://ofbiz.apache.org/dtds/widget-menu.xsd">
     <menu name="ProjectMgrAppBar" title="${uiLabelMap.ProjectMgr}" extends="CommonAppBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-
+        <menu-item name="projects" title="${uiLabelMap.WorkEffortProjects}"><link target="FindProject"/></menu-item>
         <menu-item name="mytasks" title="${uiLabelMap.WorkEffortMyTasks}"><link target="MyTasks"/></menu-item>
         <menu-item name="mytime" title="${uiLabelMap.WorkEffortTimesheetMyTime}"><link target="MyTimesheet"/></menu-item>
-        <menu-item name="projects" title="${uiLabelMap.WorkEffortProjects}"><link target="FindProject"/></menu-item>
         <menu-item name="task" title="${uiLabelMap.ProjectMgrTasks}">
             <condition>
                 <if-has-permission permission="PROJECTMGR_ADMIN"/>
@@ -55,6 +53,16 @@
                 <if-has-permission permission="PROJECTMGR_ADMIN"/>
             </condition>
             <link target="requestlist"/>
+        </menu-item>
+    </menu>
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewProject" title="${uiLabelMap.ProjectMgrNewProject}">
+            <condition>
+                <and>
+                    <if-has-permission permission="PROJECTMGR" action="_CREATE"/>
+                </and>
+            </condition>
+            <link target="EditProject"/>
         </menu-item>
     </menu>
     <menu name="ProjectTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">


### PR DESCRIPTION
Currently the create buttons for the main objects of the project mgt plugin  are located within the find and other widgets/templates of those objects.
In order to improve the usability of OFBiz (and thus the appeal of it for adopters and users) these create buttons/links/etc. should be in a main action menu visible at all times when a user is working within the component.

modified:
ProjectMenus.xml - added MainActionMenu for users with CREATE permission in the component
CommonScreens.xml - added MainActionMenu as an 'include-menu' ref in various common decorator screens.
additional cleaning.