### PR TITLE
Fixed: Eclipse build problems and proper dependency setup (OFBIZ-12808)

### DIFF
--- a/birt/build.gradle
+++ b/birt/build.gradle
@@ -23,3 +23,9 @@ dependencies {
         exclude group: 'org.eclipse.birt.runtime.3_7_1', module: 'org.apache.batik.pdf'
     }
 }
+
+configurations.all {
+    exclude group: 'org.eclipse.birt.runtime', module: 'javax.xml.stream'
+    exclude group: 'org.eclipse.birt.runtime.3_7_1', module: 'org.apache.xml.serializer'
+    exclude group: 'org.eclipse.birt.runtime.3_7_1', module: 'org.apache.xerces'
+}

--- a/ldap/build.gradle
+++ b/ldap/build.gradle
@@ -28,3 +28,12 @@
 dependencies {
     pluginLibsCompile 'org.apereo.cas:cas-server-support-ldap-core:5.0.10'
 }
+
+configurations.all {
+    exclude group: 'javax.xml.parsers', module: 'jsr173_api'
+    exclude group: 'javax.xml.namespace', module: 'jsr173_api'
+    exclude group: 'javax.xml.bind', module: 'jsr173_api'
+    exclude group: 'javax.xml.bind', module: 'jaxb-api'
+    exclude group: 'geronimo-spec', module: 'geronimo-spec-jta'
+    
+}


### PR DESCRIPTION
Due to improper dependency configurations and the JPMS (Java Plattform Module System) which was introduced to Java since version 9, the Eclipse build and running/debugging is not working with JDK 17 (trunk and release22.01).

The reason is that there are dependencies to libraries which are also shipped with the JDK which causes a conflict leading to ignore those packages/classes in the build.

This commit fixes the problems for the trunk plugins.