### PR TITLE
Fixed: Update Jersey to 2.40

### DIFF
--- a/rest-api/build.gradle
+++ b/rest-api/build.gradle
@@ -23,10 +23,10 @@ project.rootProject.configurations.all {
 }
 
 dependencies {
-    pluginLibsCompile 'org.glassfish.jersey.containers:jersey-container-servlet:2.31' // Compilation issues with 3.0.2: package javax.ws.rs does not exist
-    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-multipart:2.31'
-    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-json-jackson:2.31'
-    pluginLibsCompile 'org.glassfish.jersey.inject:jersey-hk2:2.31'
+    pluginLibsCompile 'org.glassfish.jersey.containers:jersey-container-servlet:2.40' // Compilation issues with 3.0.2 (up to 3.1.3): package javax.ws.rs does not exist
+    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-multipart:2.40'
+    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-json-jackson:2.40'
+    pluginLibsCompile 'org.glassfish.jersey.inject:jersey-hk2:2.40'
     pluginLibsCompile 'io.swagger.core.v3:swagger-jaxrs2:2.1.10'
     pluginLibsCompile 'io.swagger.core.v3:swagger-jaxrs2-servlet-initializer:2.1.10'
     pluginLibsCompile 'io.swagger.core.v3:swagger-annotations:2.1.10'


### PR DESCRIPTION
Fixed: Update Jersey to 2.40

Plugin REST API was no longer working because of the old version being incompatible with Java 17.

Thanks:  originalnichtskoenner 