### PR TITLE
Improved: MyPortal - fix PortalPagePortlet menu location (OFBIZ-12972)

### DIFF
--- a/myportal/webapp/myportal/WEB-INF/web.xml
+++ b/myportal/webapp/myportal/WEB-INF/web.xml
@@ -48,6 +48,16 @@
         <param-name>calendarMenuLocation</param-name>
         <param-value>component://workeffort/widget/WorkEffortMenus.xml</param-value>
     </context-param>
+    <context-param>
+        <description>The location of the communications menus file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>communicationMenuLocation</param-name>
+        <param-value>component://party/widget/partymgr/PartyMenus.xml</param-value>
+    </context-param>
+    <context-param>
+        <description>The location of the request menus file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>requestMenuLocation</param-name>
+        <param-value>component://order/widget/ordermgr/OrderMenus.xml</param-value>
+    </context-param>
 
     <filter>
         <display-name>ControlFilter</display-name>


### PR DESCRIPTION
Various PortalPagePortlets refer to screens in other components having embedded menus. In the originating component these menus have a parameterized menu location 'mainMenuLocation'. This does not work when a portal page is shown in a different component c.q. application as mainMenuLocation then refers to the mainMenuLocation of that component c.q. application.

modified: web.xml
- add context-param for communicationMenuLocation, requestMenuLocation