### PR TITLE
Improved: have profileMenuLocation (OFBIZ-12981)

### DIFF
--- a/myportal/webapp/myportal/WEB-INF/web.xml
+++ b/myportal/webapp/myportal/WEB-INF/web.xml
@@ -48,6 +48,11 @@
         <param-name>calendarMenuLocation</param-name>
         <param-value>component://workeffort/widget/WorkEffortMenus.xml</param-value>
     </context-param>
+    <context-param>
+        <description>The location of the profile screen menus file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>profileMenuLocation</param-name>
+        <param-value>component://party/widget/partymgr/PartyMenus.xml</param-value>
+    </context-param>
 
     <filter>
         <display-name>ControlFilter</display-name>


### PR DESCRIPTION
Profile screens are used in various components as portalpageportlets, and have references to various party menus. As menus in the various profile screens are parameterized to use ${parameters.mainMenuLocation} this generates errors in the components/applications where these screens are used as portal page elements. Having a context-param profileMenuLocation resolves this issue.

modified:
myportal-web.xml: have contex-param profileMenuLocation
