### PR TITLE
Improved: Romanian localization for EcommerceUiLabels

### DIFF
--- a/ecommerce/config/EcommerceUiLabels.xml
+++ b/ecommerce/config/EcommerceUiLabels.xml
@@ -25,6 +25,7 @@
         <value xml:lang="ja">会社案内</value>
         <value xml:lang="nl">Over ons</value>
         <value xml:lang="pt-BR">Sobre</value>
+        <value xml:lang="ro">Despre noi</value>
         <value xml:lang="vi">Giới thiệu</value>
         <value xml:lang="zh">关于我们</value>
         <value xml:lang="zh-TW">關於我們</value>
@@ -37,6 +38,7 @@
         <value xml:lang="ja">アカウント情報</value>
         <value xml:lang="nl">Account informatie</value>
         <value xml:lang="pt-BR">Informações de sua conta</value>
+        <value xml:lang="ro">Informații despre cont</value>
         <value xml:lang="vi">Thông tin tài khoản</value>
         <value xml:lang="zh">账户信息</value>
         <value xml:lang="zh-TW">帳戶資訊</value>
@@ -52,7 +54,7 @@
         <value xml:lang="ja">アカウントログイン:</value>
         <value xml:lang="nl">Uw gebruikersnaam is:</value>
         <value xml:lang="pt-BR">Seu nome de usuário é:</value>
-        <value xml:lang="ro">Utilizatorul logat este :</value>
+        <value xml:lang="ro">Numele de utilizator este:</value>
         <value xml:lang="ru">Ваше имя для учетной записи:</value>
         <value xml:lang="th">บัญชีของคุณลอกอินเข้าสู่ระบบคือ</value>
         <value xml:lang="vi">Bạn đang đăng nhập bằng tài khoản:</value>
@@ -92,7 +94,7 @@
         <value xml:lang="nl">Voeg deze (sub)lijsten toe aan de winkelwagen</value>
         <value xml:lang="pt-BR">Adicionar esta lista e suas sublistas ao carrinho</value>
         <value xml:lang="pt-PT">Adicionar Esta Lista E Sua(s) Derivada(s) Ao Cesto</value>
-        <value xml:lang="ro">Adauga Aceasta Lista si Lista(le) Fica(e) in Cos</value>
+        <value xml:lang="ro">Adăugați această listă și sublistele în coș</value>
         <value xml:lang="ru">Добавить этот и подчиненный список(ки) в корзину</value>
         <value xml:lang="th">เพิ่มรายการนี้และรายการเด็กลงตระกร้า</value>
         <value xml:lang="vi">Thêm danh sách này và các danh sách cấp dưới vào giỏ hàng</value>
@@ -108,6 +110,7 @@
         <value xml:lang="ja">追加の住所</value>
         <value xml:lang="nl">Overige adressen</value>
         <value xml:lang="pt-BR">Endereços adicionais</value>
+        <value xml:lang="ro">Adrese suplimentare</value>
         <value xml:lang="vi">Địa chỉ bổ sung</value>
         <value xml:lang="zh">附加地址</value>
         <value xml:lang="zh-TW">附加位址</value>
@@ -126,7 +129,7 @@
         <value xml:lang="nl">Voeg deze lijst toe aan de winkelwagen</value>
         <value xml:lang="pt-BR">Adicionar lista ao carrinho</value>
         <value xml:lang="pt-PT">Adicionar Lista Ao Cesto</value>
-        <value xml:lang="ro">Adauga Lista la Cos</value>
+        <value xml:lang="ro">Adaugă Lista la Coș</value>
         <value xml:lang="ru">Добавить список в корзину</value>
         <value xml:lang="th">เพิ่มรายการลงตระกร้า</value>
         <value xml:lang="vi">Thêm danh sách vào giỏ hàng</value>
@@ -142,6 +145,7 @@
         <value xml:lang="ja">新規住所を追加</value>
         <value xml:lang="nl">Toevoegen nieuw adres</value>
         <value xml:lang="pt-BR">Adicionar novo endereço</value>
+        <value xml:lang="ro">Adaugă o nouă adresă</value>
         <value xml:lang="vi">Thêm địa chỉ mới</value>
         <value xml:lang="zh">添加新地址</value>
         <value xml:lang="zh-TW">增加新的位址</value>
@@ -156,7 +160,7 @@
         <value xml:lang="ja">新規ソフトウェア製品を追加</value>
         <value xml:lang="nl">Toevoegen nieuw digitaal product</value>
         <value xml:lang="pt-BR">Adicionar novo produto digital</value>
-        <value xml:lang="ro">Adauga Nou Produs Digital</value>
+        <value xml:lang="ro">Adaugă Produs Digital</value>
         <value xml:lang="ru">Добавить новый цифровой продукт</value>
         <value xml:lang="th">เพิ่มสินค้าดิจิตัลใหม่</value>
         <value xml:lang="vi">Thêm sản phẩm kỹ thuật số mới</value>
@@ -174,7 +178,7 @@
         <value xml:lang="ja">回答を追加</value>
         <value xml:lang="nl">Toevoegen antwoord aan</value>
         <value xml:lang="pt-BR">Adicionar resposta para</value>
-        <value xml:lang="ro">Adauga raspunsuri pentru EcommerceAddSelectedtoList=Adauga Selectionat La Lista</value>
+        <value xml:lang="ro">Adaugă răspuns pentru</value>
         <value xml:lang="ru">Добавить ответ на</value>
         <value xml:lang="th">เพิ่มคำตอบสำหรับ</value>
         <value xml:lang="vi">Thêm phản hồi cho</value>
@@ -190,6 +194,7 @@
         <value xml:lang="ja">住所録</value>
         <value xml:lang="nl">Adresboek</value>
         <value xml:lang="pt-BR">Caderno de endereços</value>
+        <value xml:lang="ro">Agendă de adrese</value>
         <value xml:lang="vi">Danh bạ địa chỉ</value>
         <value xml:lang="zh">地址簿</value>
         <value xml:lang="zh-TW">位址簿</value>
@@ -207,6 +212,7 @@
         <value xml:lang="nl">Voeg geselecteerde toe aan de lijst</value>
         <value xml:lang="pt-BR">Adicionar selecionados à lista</value>
         <value xml:lang="pt-PT">Adicionar Seleccionado À Lista</value>
+        <value xml:lang="ro">Adăugați selecția la listă</value>
         <value xml:lang="ru">Добавить выбранное в список</value>
         <value xml:lang="th">เพิ่มที่เลือกลงสู่รายการ</value>
         <value xml:lang="vi">Thêm phần đã chọn vào danh sách</value>
@@ -219,6 +225,7 @@
         <value xml:lang="fr">Ajouter une étiquette</value>
         <value xml:lang="ja">タグを追加</value>
         <value xml:lang="nl">Tag toevoegen</value>
+        <value xml:lang="ro">Adăugați etichete</value>
         <value xml:lang="vi">Thêm đánh dấu</value>
         <value xml:lang="zh">添加标签</value>
         <value xml:lang="zh-TW">增加標籤</value>
@@ -229,6 +236,7 @@
         <value xml:lang="fr">Utiliser un espace pour séparer les étiquettes et des apostrophes pour les phrases.</value>
         <value xml:lang="ja">タグの区切りはスペースを使用してください。フレーズにはシングルクォート(')を使用してください。</value>
         <value xml:lang="nl">Meerder tags met spatie scheiden.</value>
+        <value xml:lang="ro">Folosiți spații pentru a separa etichetele. Folosiți ghilimele simple(') pentru fraze.</value>
         <value xml:lang="vi">Dùng phím cách (space) để ngăn cách các Tag, sử dụng dấu nháy đơn (') cho các từ.</value>
         <value xml:lang="zh">使用空格分隔标签。使用单引号(')来表示词组。</value>
         <value xml:lang="zh-TW">使用空格分隔標籤.使用單引號(')來表示片語.</value>
@@ -239,6 +247,7 @@
         <value xml:lang="fr">Ajouter vos étiquettes</value>
         <value xml:lang="ja">あなたのタグを追加</value>
         <value xml:lang="nl">Voeg tag toe</value>
+        <value xml:lang="ro">Adăugați etichetele dvs</value>
         <value xml:lang="vi">Thêm vào đánh dấu của bạn</value>
         <value xml:lang="zh">添加你的标签</value>
         <value xml:lang="zh-TW">增加你的標籤</value>
@@ -256,7 +265,7 @@
         <value xml:lang="nl">Aanpassing</value>
         <value xml:lang="pt-BR">Ajuste</value>
         <value xml:lang="pt-PT">Ajuste</value>
-        <value xml:lang="ro">Modificare</value>
+        <value xml:lang="ro">Ajustare</value>
         <value xml:lang="ru">Настройка</value>
         <value xml:lang="th">ส่วนลด</value>
         <value xml:lang="vi">Điều chỉnh</value>
@@ -276,7 +285,7 @@
         <value xml:lang="nl">Correcties</value>
         <value xml:lang="pt-BR">Ajustes</value>
         <value xml:lang="pt-PT">Ajustes</value>
-        <value xml:lang="ro">Modificari</value>
+        <value xml:lang="ro">Ajustări</value>
         <value xml:lang="ru">Настройки</value>
         <value xml:lang="th">ส่วนลด</value>
         <value xml:lang="vi">Điều chỉnh</value>
@@ -288,6 +297,7 @@
         <value xml:lang="it">Record affiliato creato con successo.</value>
         <value xml:lang="ja">アフェリエイトレコードが正しく作成されました。</value>
         <value xml:lang="nl">Affiliatie aangemaakt</value>
+        <value xml:lang="ro">Înregistrarea afiliatului a fost realizată cu succes.</value>
         <value xml:lang="vi">Bản đăng ký hội viên được tạo thành công.</value>
         <value xml:lang="zh">成功创建了从属记录。</value>
         <value xml:lang="zh-TW">成功新建了從屬記錄.</value>
@@ -305,7 +315,7 @@
         <value xml:lang="ja">アイテムを追加した後にいつも買い物かごを表示</value>
         <value xml:lang="nl">Bekijk de winkelwagen altijd na het toevoegen</value>
         <value xml:lang="pt-BR">Sempre exibir carrinho após adicionar um item</value>
-        <value xml:lang="ro">Vezi cosul numai dupa ce ai adaugat o linie</value>
+        <value xml:lang="ro">Vezi cosul după ce ai adaugat un articol</value>
         <value xml:lang="ru">Всегда просматривать корзину перед добавлением позиции</value>
         <value xml:lang="th">ดูรายการในตะกร้าหลังจากเพิ่มสินค้าเสมอ</value>
         <value xml:lang="vi">Luôn hiển thị giỏ hàng khi thêm vào một sản phẩm</value>
@@ -323,7 +333,7 @@
         <value xml:lang="ja">記事情報</value>
         <value xml:lang="nl">Artikelinformatie</value>
         <value xml:lang="pt-BR">Informação do artigo</value>
-        <value xml:lang="ro">Articol</value>
+        <value xml:lang="ro">Informații Articol</value>
         <value xml:lang="ru">Информация по статье</value>
         <value xml:lang="th">ข้อมูลบทความ</value>
         <value xml:lang="vi">Thông tin bài viết</value>
@@ -335,6 +345,7 @@
         <value xml:lang="fr">Disponible :</value>
         <value xml:lang="ja">有効</value>
         <value xml:lang="nl">Beschikbaar</value>
+        <value xml:lang="ro">Disponibil:</value>
         <value xml:lang="vi">Có sẵn:</value>
         <value xml:lang="zh">有效：</value>
         <value xml:lang="zh-TW">可用:</value>
@@ -359,6 +370,7 @@
         <value xml:lang="en">Best Selling</value>
         <value xml:lang="fr">Meilleures ventes</value>
         <value xml:lang="nl">Bestverkopend</value>
+    <value xml:lang="ro">Cel mai vândut</value>
     </property>
     <property key="EcommerceBeSureToIncludeYourOrderNb">
         <value xml:lang="da">Husk at inkludere din ordre</value>
@@ -370,7 +382,7 @@
         <value xml:lang="ja">注文Noを確認してください</value>
         <value xml:lang="nl">Vergeet niet het bestellingnummer op te geven</value>
         <value xml:lang="pt-BR">Certifique-se de incluir número de pedido</value>
-        <value xml:lang="ro">Asigurate ca ai inclus comanda ta #</value>
+        <value xml:lang="ro">Asigură-te că ai inclus numărul comenzii</value>
         <value xml:lang="ru">Убедитесь что указали № заказа</value>
         <value xml:lang="th">แน่ใจในการรวมรายการสินค้าของคุณ #</value>
         <value xml:lang="vi">Chắc chắn rằng bao gồm cả đặt hàng #</value>
@@ -385,6 +397,7 @@
         <value xml:lang="ja">回答を追加</value>
         <value xml:lang="nl">Toevoegen antwoord:</value>
         <value xml:lang="pt-BR">Adicionar uma resposta:</value>
+        <value xml:lang="ro">Adăugați un răspuns:</value>
         <value xml:lang="vi">Thêm một phản hồi:</value>
         <value xml:lang="zh">添加一个回答：</value>
         <value xml:lang="zh-TW">增加一個回應:</value>
@@ -397,6 +410,7 @@
         <value xml:lang="ja">回答の追加はログインしてください。</value>
         <value xml:lang="nl">U moet ingelogd zijn om een antwoord toe te kunnen voegen.</value>
         <value xml:lang="pt-BR">Você deve registrar-se para adicionar uma resposta</value>
+        <value xml:lang="ro">Trebuie să fii autentificat pentru a adăuga un răspuns.</value>
         <value xml:lang="vi">Bạn cần phải đăng nhập để thêm một phản hồi.</value>
         <value xml:lang="zh">你必须登录才能添加一个回答。</value>
         <value xml:lang="zh-TW">你必須登入才能增加一個回應.</value>
@@ -405,6 +419,7 @@
         <value xml:lang="en">You do not have permission to add comment.</value>
         <value xml:lang="ja">コメントを追加する権限がありません。</value>
         <value xml:lang="nl">Geen permissies om commentaar toe te voegen</value>
+        <value xml:lang="ro">Nu aveți permisiunea de a adăuga un comentariu.</value>
         <value xml:lang="th">คุณไม่มีสิทธิ์ในการแสดงความคิดเห็น</value>
         <value xml:lang="vi">Bạn không được quyền thêm Diễn giải.</value>
         <value xml:lang="zh">你没有添加评论的权限。</value>
@@ -418,6 +433,7 @@
         <value xml:lang="ja">スレッドを追加:</value>
         <value xml:lang="nl">Start een discussie:</value>
         <value xml:lang="pt-BR">Adicionar um tópico de discussão</value>
+        <value xml:lang="ro">Adauga un subiect:</value>
         <value xml:lang="vi">Thêm luồng thảo luận:</value>
         <value xml:lang="zh">添加一个线索：</value>
         <value xml:lang="zh-TW">增加一個討論:</value>
@@ -430,6 +446,7 @@
         <value xml:lang="ja">ブログのコンテンツが見つかりません!</value>
         <value xml:lang="nl">Kan blog content niet vinden!</value>
         <value xml:lang="pt-BR">Impossível encontrar conteúdo de blog!</value>
+        <value xml:lang="ro">Nu se poate găsi conținutul blogului!</value>
         <value xml:lang="vi">Không thể tìm thấy nội dung Blog!</value>
         <value xml:lang="zh">无法找到博客内容！</value>
         <value xml:lang="zh-TW">無法找到部落格內容！</value>
@@ -442,6 +459,7 @@
         <value xml:lang="ja">コメントの編集はログインしてください。</value>
         <value xml:lang="nl">U moet ingelogd zijn om commentaren te wijzigen.</value>
         <value xml:lang="pt-BR">Você deve registrar-se para editar comentários</value>
+        <value xml:lang="ro">Trebuie să fii autentificat pentru a edita comentariile.</value>
         <value xml:lang="vi">Bạn cần phải đăng nhập để thực hiện việc chỉnh sửa Diễn giải.</value>
         <value xml:lang="zh">你必须登录以便编辑评论。</value>
         <value xml:lang="zh-TW">你必須登入以便編輯評論.</value>
@@ -454,6 +472,7 @@
         <value xml:lang="ja">メッセージすべて</value>
         <value xml:lang="nl">Volledig(e) bericht</value>
         <value xml:lang="pt-BR">Mensagem completa</value>
+        <value xml:lang="ro">Mesaj complet</value>
         <value xml:lang="vi">Tin nhắn đầy đủ</value>
         <value xml:lang="zh">完整消息</value>
         <value xml:lang="zh-TW">完整訊息</value>
@@ -466,6 +485,7 @@
         <value xml:lang="ja">最新回答</value>
         <value xml:lang="nl">Laatste antwoorden</value>
         <value xml:lang="pt-BR">Últimas respostas</value>
+        <value xml:lang="ro">Ultimele răspunsuri</value>
         <value xml:lang="vi">Phản hồi mới nhất</value>
         <value xml:lang="zh">最新回答</value>
         <value xml:lang="zh-TW">最新回應</value>
@@ -478,6 +498,7 @@
         <value xml:lang="ja">メッセージツリー</value>
         <value xml:lang="nl">Berichten structuur</value>
         <value xml:lang="pt-BR">Árvore de mensagens</value>
+        <value xml:lang="ro">Arborele de mesaje</value>
         <value xml:lang="vi">Cây tin nhắn</value>
         <value xml:lang="zh">消息树</value>
         <value xml:lang="zh-TW">訊息樹</value>
@@ -490,6 +511,7 @@
         <value xml:lang="ja">コメントの投稿は、ログインして公開済みのレコードを表示してください。</value>
         <value xml:lang="nl">U moet ingelogd zijn en een bericht bekijken om commentaar te kunnen plaatsten.</value>
         <value xml:lang="pt-BR">Você deve registrar-se e estar visualizando um item publicado para poder fazer comentários.</value>
+        <value xml:lang="ro">Trebuie să fiți autentificat și să vizualizați o înregistrare publicată pentru a posta comentarii.</value>
         <value xml:lang="vi">Bạn cần phải đăng nhập và xem lại bản ghi trước khi yêu cầu đăng Diễn giải.</value>
         <value xml:lang="zh">为了提交评论，你必须登录，并浏览一条已发布的记录。</value>
         <value xml:lang="zh-TW">為了提交評論,你必須登入,並檢視一筆已發佈的資料.</value>
@@ -502,6 +524,7 @@
         <value xml:lang="ja">投稿</value>
         <value xml:lang="nl">Geplaatst op</value>
         <value xml:lang="pt-BR">Enviado em</value>
+        <value xml:lang="ro">Postat pe</value>
         <value xml:lang="vi">Đăng vào lúc</value>
         <value xml:lang="zh">提交</value>
         <value xml:lang="zh-TW">提交</value>
@@ -514,6 +537,7 @@
         <value xml:lang="ja">ブログ記事の表示</value>
         <value xml:lang="nl">Bekijk blog artikel</value>
         <value xml:lang="pt-BR">Ver artigo do blog</value>
+        <value xml:lang="ro">Vezi articolul de blog</value>
         <value xml:lang="vi">Xem nội dung bài viết blog</value>
         <value xml:lang="zh">浏览博客文章</value>
         <value xml:lang="zh-TW">檢視部落格文章</value>
@@ -526,6 +550,7 @@
         <value xml:lang="ja">ブロンズ</value>
         <value xml:lang="nl">Brons</value>
         <value xml:lang="pt-BR">Bronze</value>
+        <value xml:lang="ro">Bronz</value>
         <value xml:lang="vi">Đồng (kim loại)</value>
         <value xml:lang="zh">铜牌</value>
         <value xml:lang="zh-TW">銅牌</value>
@@ -544,7 +569,7 @@
         <value xml:lang="nl">Winkelwagen heeft</value>
         <value xml:lang="pt-BR">Carrinho tem</value>
         <value xml:lang="pt-PT">O Cesto contém</value>
-        <value xml:lang="ro">Cosul are </value>
+        <value xml:lang="ro">Coșul are</value>
         <value xml:lang="ru">В корзине</value>
         <value xml:lang="th">ตระกร้ามี</value>
         <value xml:lang="vi">Giỏ hàng có</value>
@@ -565,7 +590,7 @@
         <value xml:lang="nl">Winkelwagen totaal</value>
         <value xml:lang="pt-BR">Total do carrinho</value>
         <value xml:lang="pt-PT">Total no Cesto</value>
-        <value xml:lang="ro">Total Cos</value>
+        <value xml:lang="ro">Total Coș</value>
         <value xml:lang="ru">Всего в корзине</value>
         <value xml:lang="th">ผลรวมตระกร้า</value>
         <value xml:lang="vi">Tổng cộng giỏ hàng</value>
@@ -584,7 +609,7 @@
         <value xml:lang="ja">支払情報を変更</value>
         <value xml:lang="nl">Aanpassen betaalinformatie</value>
         <value xml:lang="pt-BR">Alterar dados de pagamento</value>
-        <value xml:lang="ro">Schimbare Informatii Plata </value>
+        <value xml:lang="ro">Modifică Informații Plată</value>
         <value xml:lang="ru">Изменить платежную информацию</value>
         <value xml:lang="th">เปลี่ยนแปลงข้อมูลการชำระเงิน</value>
         <value xml:lang="vi">Thay đổi thông tin thanh toán</value>
@@ -604,7 +629,7 @@
         <value xml:lang="ja">発送先住所を変更</value>
         <value xml:lang="nl">Aanpassen verzendadres</value>
         <value xml:lang="pt-BR">Alterar endereço para envio</value>
-        <value xml:lang="ro">Schimbare Adresa Expediere </value>
+        <value xml:lang="ro">Modifică Adresă Livrare</value>
         <value xml:lang="ru">Изменить адрес доставки</value>
         <value xml:lang="th">เปลี่ยนแปลงที่อยู่ในการส่งของ</value>
         <value xml:lang="vi">Thay đổi địa chỉ nhận hàng</value>
@@ -620,7 +645,7 @@
         <value xml:lang="ja">発送オプションを変更</value>
         <value xml:lang="nl">Aanpassen verzendopties</value>
         <value xml:lang="pt-BR">Alterar opções de envio</value>
-        <value xml:lang="ro">Schimbare Optiuni Expediere </value>
+        <value xml:lang="ro">Modifică Opțiuni Livrare</value>
         <value xml:lang="ru">Изменить параметры доставки</value>
         <value xml:lang="th">เปลี่ยนแปลงทางเลือกในการส่งของ</value>
         <value xml:lang="vi">Thay đổi các tùy chọn nhận hàng</value>
@@ -637,7 +662,7 @@
         <value xml:lang="ja">残高確認</value>
         <value xml:lang="nl">Bekijk saldo</value>
         <value xml:lang="pt-BR">Verificar saldo</value>
-        <value xml:lang="ro">Controleaza Bilantul </value>
+        <value xml:lang="ro">Verifică Soldul</value>
         <value xml:lang="ru">Проверить баланс</value>
         <value xml:lang="th">ตรวสอบยอดคงเหลือ</value>
         <value xml:lang="vi">Kiểm tra tài khoản</value>
@@ -656,7 +681,7 @@
         <value xml:lang="nl">Sublijst totaalprijs</value>
         <value xml:lang="pt-BR">Preço total da sublista</value>
         <value xml:lang="pt-PT">Preço Total Das Listas Derivadas</value>
-        <value xml:lang="ro">Liste Fice Pret Total</value>
+        <value xml:lang="ro">Preț Total Sublistă</value>
         <value xml:lang="ru">Общая цена подчиненного списка</value>
         <value xml:lang="th">รายการราคาของสินค้าเด็ก</value>
         <value xml:lang="vi">Tổng giá danh mục thành phần</value>
@@ -675,7 +700,7 @@
         <value xml:lang="nl">Sub boodschappenlijst</value>
         <value xml:lang="pt-BR">Sublista de compras</value>
         <value xml:lang="pt-PT">Listas de Compras Derivadas</value>
-        <value xml:lang="ro">Liste Fice Cumparari </value>
+        <value xml:lang="ro">Sublistă de cumpărături</value>
         <value xml:lang="ru">Подчиненный список покупок</value>
         <value xml:lang="th">รายการที่สั่งซื้อสินค้าเด็ก</value>
         <value xml:lang="vi">Danh sách mua hàng thành phần</value>
@@ -691,6 +716,7 @@
         <value xml:lang="ja">編集はここをクリック</value>
         <value xml:lang="nl">Klik hier om te wijzgen</value>
         <value xml:lang="pt-BR">Clique aqui para alterar</value>
+        <value xml:lang="ro">Click aici pentru a edita</value>
         <value xml:lang="vi">Bấm vào đây để chỉnh sửa</value>
         <value xml:lang="zh">点击这里编辑</value>
         <value xml:lang="zh-TW">點擊這裡編輯</value>
@@ -706,7 +732,7 @@
         <value xml:lang="ja">完了しました</value>
         <value xml:lang="nl">Volledig ingevuld, bedankt!</value>
         <value xml:lang="pt-BR">Completado</value>
-        <value xml:lang="ro">Indeplinit - Multumesc!</value>
+        <value xml:lang="ro">Completat</value>
         <value xml:lang="ru">Завершена - Спасибо!</value>
         <value xml:lang="th">เสร็จสมบูรณ์</value>
         <value xml:lang="vi">Hoàn thành</value>
@@ -724,7 +750,7 @@
         <value xml:lang="ja">コンテンツ</value>
         <value xml:lang="nl">Content voor</value>
         <value xml:lang="pt-BR">Conteúdo para</value>
-        <value xml:lang="ro">Continut pentru </value>
+        <value xml:lang="ro">Conținut pentru</value>
         <value xml:lang="ru">Содержимое для</value>
         <value xml:lang="th">หัวข้อสำหรับ</value>
         <value xml:lang="vi">Nội dung cho</value>
@@ -742,7 +768,7 @@
         <value xml:lang="ja">コンテンツ情報</value>
         <value xml:lang="nl">Content informatie</value>
         <value xml:lang="pt-BR">Informações de conteúdo</value>
-        <value xml:lang="ro">Informatie Continut</value>
+        <value xml:lang="ro">Informații Conținut</value>
         <value xml:lang="ru">Информация о содержимом</value>
         <value xml:lang="th">ข้อมูลหัวข้อ</value>
         <value xml:lang="vi">Thông tin nội dung</value>
@@ -760,7 +786,7 @@
         <value xml:lang="ja">コンテンツ名称</value>
         <value xml:lang="nl">Content naam</value>
         <value xml:lang="pt-BR">Nome de conteúdo</value>
-        <value xml:lang="ro">Nume Continut</value>
+        <value xml:lang="ro">Nume Conținut</value>
         <value xml:lang="ru">Имя содержимого</value>
         <value xml:lang="th">ชื่อหัวข้อ</value>
         <value xml:lang="vi">Tên nội dung</value>
@@ -780,7 +806,7 @@
         <value xml:lang="nl">Doorgaan met winkelen</value>
         <value xml:lang="pt-BR">Continuar comprando</value>
         <value xml:lang="pt-PT">Continuar as Compras</value>
-        <value xml:lang="ro">Continua Cumparare</value>
+        <value xml:lang="ro">Continuă Cumpărăturile</value>
         <value xml:lang="ru">Продолжить покупки</value>
         <value xml:lang="th">ทำการซื้อสินค้าต่อไป</value>
         <value xml:lang="vi">Tiếp tục mua hàng</value>
@@ -796,6 +822,7 @@
         <value xml:lang="ja">ステップを続ける</value>
         <value xml:lang="nl">Doorgaan naar stap</value>
         <value xml:lang="pt-BR">Continuar (próxima etapa)</value>
+        <value xml:lang="ro">Continuați cu pasul</value>
         <value xml:lang="vi">Tiếp tục các bước</value>
         <value xml:lang="zh">继续步骤</value>
         <value xml:lang="zh-TW">繼續步驟</value>
@@ -803,22 +830,27 @@
     <property key="EcommerceCookieConsentTitle">
         <value xml:lang="en">This website uses cookies</value>
         <value xml:lang="nl">Deze website gebruikt cookies</value>
+    <value xml:lang="ro">Acest website folosește cookie-uri</value>
     </property>
     <property key="EcommerceCookieConsentMessage">
         <value xml:lang="en">We use cookies to provide our services. By using this website, you agree to this.</value>
         <value xml:lang="nl">Wij gebruiken cookies om onze diensten te leveren. Door gebruik te maken van deze webshop, gaat u hiermee accoord.</value>
+    <value xml:lang="ro">Folosim cookie-uri pentru functionarea serviciilor noastre. Prin utilizarea acestui website, sunteți de acord cu acest lucru.</value>
     </property>
     <property key="EcommerceCookieConsentMoreLinkLabel">
         <value xml:lang="en">More</value>
         <value xml:lang="nl">Meer..</value>
+    <value xml:lang="ro">Mai mult</value>
     </property>
     <property key="EcommerceCookieConsentAcceptButtonLabel">
         <value xml:lang="en">Accept</value>
         <value xml:lang="nl">Accepteren</value>
+    <value xml:lang="ro">Acceptă</value>
     </property>
     <property key="EcommerceCookieConsentAdvancedButtonLabel">
         <value xml:lang="en">Customize</value>
         <value xml:lang="nl">Aanpassen</value>
+    <value xml:lang="ro">Personalizați</value>
     </property>
     <property key="EcommerceDataResourceId">
         <value xml:lang="da">Dataresurse ID</value>
@@ -831,7 +863,7 @@
         <value xml:lang="ja">データリソースID</value>
         <value xml:lang="nl">Databron ID</value>
         <value xml:lang="pt-BR">ID de fonte de dados</value>
-        <value xml:lang="ro">Cod Resursa Date</value>
+        <value xml:lang="ro">Id Resursă Date</value>
         <value xml:lang="ru">Data Resource ID</value>
         <value xml:lang="th">หมายเลขแหล่งที่มา</value>
         <value xml:lang="vi">Tài nguyên dữ liệu</value>
@@ -847,6 +879,7 @@
         <value xml:lang="ja">通常の住所</value>
         <value xml:lang="nl">Standaard adres</value>
         <value xml:lang="pt-BR">Endereço principal</value>
+        <value xml:lang="ro">Adrese implicite</value>
         <value xml:lang="vi">Địa chỉ mặc định</value>
         <value xml:lang="zh">缺省地址</value>
         <value xml:lang="zh-TW">預設位址</value>
@@ -861,7 +894,7 @@
         <value xml:lang="ja">通常の発送方法</value>
         <value xml:lang="nl">Standaard verzendmethode</value>
         <value xml:lang="pt-BR">Método de envio padrão</value>
-        <value xml:lang="ro">Metoda de Expediere de Default</value>
+        <value xml:lang="ro">Metoda de Livrare implicită</value>
         <value xml:lang="ru">Обычный метод доставки</value>
         <value xml:lang="th">วิธีการขนส่ง</value>
         <value xml:lang="vi">Phương thức giao hàng mặc định</value>
@@ -879,7 +912,7 @@
         <value xml:lang="ja">通常使用する発送先住所を選択してください; その後通常使用する発送方法を選択してください。</value>
         <value xml:lang="nl">Selecteer uw standaard verzendadres en daarna uw standaard verzendopties</value>
         <value xml:lang="pt-BR">Por favor selecione seu endereço de envio padrão; então selecione o seu método de envio padrão.</value>
-        <value xml:lang="ro">Te rugam sa selectionezi adresa ta de expediere de default; selectioneaza apoi o metoda de expediere de default.</value>
+        <value xml:lang="ro">Te rugăm să selectezi adresa de livrare implicită; apoi selectează o metodă de livrare implicită.</value>
         <value xml:lang="ru">Пожалуйста выберите ваш обычный адрес доставки; затем выберите обычные способ доставки.</value>
         <value xml:lang="th">กรุณาเลือกที่อยู่ในการขนส่ง; จากนั้นเลือกวิธีการขนส่ง</value>
         <value xml:lang="vi">Vui lòng lựa chọn địa chỉ giao hàng mặc định; sau đó lựa chọn phương thức giao hàng mặc định.</value>
@@ -896,7 +929,7 @@
         <value xml:lang="ja">ファイルからデータを追加</value>
         <value xml:lang="nl">Digitale toevoegen van mijn bestanden</value>
         <value xml:lang="pt-BR">Adição com fonte nos meus arquivos</value>
-        <value xml:lang="ro">Adauga Din Fisierele mele</value>
+        <value xml:lang="ro">Adaugă Din Fișierele Mele</value>
         <value xml:lang="ru">Добавить из моих файлов</value>
         <value xml:lang="th">สินค้าดิจิตัลที่เพิ่มจากไฟล์ของฉัน</value>
         <value xml:lang="vi">Thêm nội dung từ Tài liệu của tôi</value>
@@ -913,7 +946,7 @@
         <value xml:lang="ja">新規ソフトウェア製品</value>
         <value xml:lang="nl">Nieuw digitaal product</value>
         <value xml:lang="pt-BR">Novo produto digital</value>
-        <value xml:lang="ro">Nou Produs Digital</value>
+        <value xml:lang="ro">Produs Digital Nou</value>
         <value xml:lang="ru">Новый цифровой продукт</value>
         <value xml:lang="th">สินค้าดิจิตัลใหม่</value>
         <value xml:lang="vi">Thêm sản phẩm</value>
@@ -930,7 +963,7 @@
         <value xml:lang="ja">ソフトウェア製品ファイル</value>
         <value xml:lang="nl">Digitale product bestanden</value>
         <value xml:lang="pt-BR">Arquivos de produtos digitais</value>
-        <value xml:lang="ro">Fisiere Produse Digitale</value>
+        <value xml:lang="ro">Fișiere Produse Digitale</value>
         <value xml:lang="ru">Файлы цифровых продуктов</value>
         <value xml:lang="th">ไฟล์สินค้าดิจิตัล</value>
         <value xml:lang="vi">Tài liệu sản phẩm</value>
@@ -947,7 +980,7 @@
         <value xml:lang="ja">ソフトウェア製品購入履歴委託</value>
         <value xml:lang="nl">Commissie geschiedenis voor digitale producten</value>
         <value xml:lang="pt-BR">Histórico de comissões por compras de produtos digitais</value>
-        <value xml:lang="ro">Storia Cumparari si  Provizioane Produse Digitale</value>
+        <value xml:lang="ro">Istoricul comisionului pentru achizițiile de produse digitale</value>
         <value xml:lang="ru">История и комиссии приобретения цифровых продуктов</value>
         <value xml:lang="th">ข้อมูลค่าคอมมิชชั่นในการสั่งซื้อสินค้าดิจิตัล</value>
         <value xml:lang="vi">Lịch sử hoa hồng mua hàng</value>
@@ -965,7 +998,7 @@
         <value xml:lang="ja">ソフトウェア製品アップロード</value>
         <value xml:lang="nl">Uploaden digitale producten</value>
         <value xml:lang="pt-BR">Upload de produto digital</value>
-        <value xml:lang="ro">Upload Produs Digital</value>
+        <value xml:lang="ro">Încarcă Produs Digital</value>
         <value xml:lang="ru">Загрузка цифровой продукции</value>
         <value xml:lang="th">โหลดสินค้าดิจิตัล</value>
         <value xml:lang="vi">Tải lên sản phẩm</value>
@@ -983,7 +1016,7 @@
         <value xml:lang="ja">ダウンロード対象はありません</value>
         <value xml:lang="nl">Download niet gevonden</value>
         <value xml:lang="pt-BR">Arquivo não encontrado</value>
-        <value xml:lang="ro">Nici-un Download de Fisiere Gasit</value>
+        <value xml:lang="ro">Niciun fișier găsit</value>
         <value xml:lang="ru">Нет файлов для загрузки</value>
         <value xml:lang="th">ไม่พบที่ดาวโหลด</value>
         <value xml:lang="vi">Hiện không có nội dung tải xuống</value>
@@ -1001,7 +1034,7 @@
         <value xml:lang="ja">ダウンロード可能タイトル</value>
         <value xml:lang="nl">Download beschikbare titel</value>
         <value xml:lang="pt-BR">Baixar os arquivos disponíveis</value>
-        <value xml:lang="ro">Download de Fisiere Disponibile</value>
+        <value xml:lang="ro">Fișiere disponibile pentru descărcare</value>
         <value xml:lang="ru">Доступны файлы для загрузки</value>
         <value xml:lang="th">โหลดหัวข้อที่มีอยู่</value>
         <value xml:lang="vi">Tên các nội dung có sẵn để tải xuống</value>
@@ -1017,6 +1050,7 @@
         <value xml:lang="ja">プロファイルを編集</value>
         <value xml:lang="nl">Wijzigen profiel</value>
         <value xml:lang="pt-BR">Editar perfil</value>
+        <value xml:lang="ro">Editați profilul</value>
         <value xml:lang="vi">Soạn thảo hồ sơ</value>
         <value xml:lang="zh">编辑个人信息</value>
         <value xml:lang="zh-TW">編輯個人資訊</value>
@@ -1029,6 +1063,7 @@
         <value xml:lang="ja">このコメントを編集</value>
         <value xml:lang="nl">Wijzig dit commentaar</value>
         <value xml:lang="pt-BR">Editar este comentário</value>
+        <value xml:lang="ro">Editează acest comentariu</value>
         <value xml:lang="vi">Chỉnh sửa Diễn giải này</value>
         <value xml:lang="zh">编辑这个评论</value>
         <value xml:lang="zh-TW">編輯這個評論</value>
@@ -1044,7 +1079,7 @@
         <value xml:lang="ja">何も入っていない本文</value>
         <value xml:lang="nl">Geen inhoud</value>
         <value xml:lang="pt-BR">Conteúdo vazio</value>
-        <value xml:lang="ro">Corp Gol</value>
+        <value xml:lang="ro">Conținut Gol</value>
         <value xml:lang="ru">Пусто</value>
         <value xml:lang="th">ไม่มีข้อมูล</value>
         <value xml:lang="vi">Phần thân trống</value>
@@ -1065,7 +1100,7 @@
         <value xml:lang="nl">Leeg winkelwagen</value>
         <value xml:lang="pt-BR">Carrinho vazio</value>
         <value xml:lang="pt-PT">Cesto Vazio</value>
-        <value xml:lang="ro">Cos Gol</value>
+        <value xml:lang="ro">Coș Gol</value>
         <value xml:lang="ru">Корзина пустая</value>
         <value xml:lang="th">ตะกร้าว่างเปล่า</value>
         <value xml:lang="vi">Giỏ hàng trống</value>
@@ -1081,6 +1116,7 @@
         <value xml:lang="ja">プロモーションコードを入力</value>
         <value xml:lang="nl">Opgeven promotiecode</value>
         <value xml:lang="pt-BR">Escreva o código promocional</value>
+        <value xml:lang="ro">Introdu codul promoțional</value>
         <value xml:lang="vi">Nhập mã khuyến mại</value>
         <value xml:lang="zh">输入促销代码</value>
         <value xml:lang="zh-TW">輸入促銷碼</value>
@@ -1096,7 +1132,7 @@
         <value xml:lang="ja">照会パラメータを入力</value>
         <value xml:lang="nl">Vul zoekwoorden in</value>
         <value xml:lang="pt-BR">Entre com os parâmetros para busca</value>
-        <value xml:lang="ro">Introdu parametrii de cautare</value>
+        <value xml:lang="ro">Introdu parametrii de căutare</value>
         <value xml:lang="ru">Введите параметры запроса</value>
         <value xml:lang="th">เข้าไปดูคำถาม</value>
         <value xml:lang="vi">Nhập thông số truy vấn</value>
@@ -1114,7 +1150,7 @@
         <value xml:lang="ja">次回注文予定日</value>
         <value xml:lang="nl">Geschatte datum voor the volgende bestelling</value>
         <value xml:lang="pt-BR">Estimativa para a data do próximo pedido</value>
-        <value xml:lang="ro">Stimeza Urmatoarea Data a Comenzii </value>
+        <value xml:lang="ro">Data estimată a următoarei comenzi</value>
         <value xml:lang="ru">Оценочная дата следующего заказа</value>
         <value xml:lang="th">วันที่ที่คาดว่าจะทำรายการครั้งต่อไป</value>
         <value xml:lang="vi">Dự kiến ngày đặt hàng kế tiếp</value>
@@ -1132,7 +1168,7 @@
         <value xml:lang="ja">毎月3日</value>
         <value xml:lang="nl">Elke derde</value>
         <value xml:lang="pt-BR">Cada 3</value>
-        <value xml:lang="ro">La fiecare a-3-a</value>
+        <value xml:lang="ro">La fiecare a 3-a</value>
         <value xml:lang="ru">Каждый 3-й</value>
         <value xml:lang="th">ทุก ๆ วันที่ 3</value>
         <value xml:lang="vi">Vào mỗi lần thứ 3</value>
@@ -1150,7 +1186,7 @@
         <value xml:lang="ja">毎月6日</value>
         <value xml:lang="nl">Elke zesde</value>
         <value xml:lang="pt-BR">Cada 6</value>
-        <value xml:lang="ro">La fiecare a-6-a</value>
+        <value xml:lang="ro">La fiecare a 6-a</value>
         <value xml:lang="ru">Каждый 6-й</value>
         <value xml:lang="th">ทุก ๆ วันที่ 6</value>
         <value xml:lang="vi">Vào mỗi lần thứ 6</value>
@@ -1168,7 +1204,7 @@
         <value xml:lang="ja">毎月9日</value>
         <value xml:lang="nl">Elke negende</value>
         <value xml:lang="pt-BR">Cada 9</value>
-        <value xml:lang="ro">La fiecare a-9-a</value>
+        <value xml:lang="ro">La fiecare a 9-a</value>
         <value xml:lang="ru">Каждый 9-й</value>
         <value xml:lang="th">ทุก ๆ วันที่ 9</value>
         <value xml:lang="vi">Vào mỗi lần thứ 9</value>
@@ -1186,7 +1222,7 @@
         <value xml:lang="ja">毎日</value>
         <value xml:lang="nl">Elke</value>
         <value xml:lang="pt-BR">Todos os dias</value>
-        <value xml:lang="ro">In fiecare zi</value>
+        <value xml:lang="ro">În fiecare zi</value>
         <value xml:lang="ru">Каждый</value>
         <value xml:lang="th">ทุก ๆ วัน</value>
         <value xml:lang="vi">Hàng ngày</value>
@@ -1204,7 +1240,7 @@
         <value xml:lang="ja">隔日</value>
         <value xml:lang="nl">Elke andere</value>
         <value xml:lang="pt-BR">Todos os outros</value>
-        <value xml:lang="ro">Oricand</value>
+        <value xml:lang="ro">Din două în două</value>
         <value xml:lang="ru">Каждый другой</value>
         <value xml:lang="th">ทุกครั้ง</value>
         <value xml:lang="vi">Vào mỗi lần</value>
@@ -1222,7 +1258,7 @@
         <value xml:lang="ja">税抜金額</value>
         <value xml:lang="nl">Uitgesloten hoeveelheid</value>
         <value xml:lang="pt-BR">Quantidade isenta</value>
-        <value xml:lang="ro">Valoare Scutita</value>
+        <value xml:lang="ro">Valoare Scutită</value>
         <value xml:lang="ru">Безналоговая сумма</value>
         <value xml:lang="th">จำนวนตัวอย่าง</value>
         <value xml:lang="vi">Tổng số miễn thuế</value>
@@ -1242,7 +1278,7 @@
         <value xml:lang="nl">Wist u dat?</value>
         <value xml:lang="pt">Você Sabia?</value>
         <value xml:lang="pt-BR">Você sabia?</value>
-        <value xml:lang="ro">Factoids</value>
+        <value xml:lang="ro">Știați că?</value>
         <value xml:lang="ru">Факты</value>
         <value xml:lang="th">คุณทราบหรือไม่ ?</value>
         <value xml:lang="vi">Tin nóng bạn cần biết</value>
@@ -1260,7 +1296,7 @@
         <value xml:lang="ja">ファイル管理</value>
         <value xml:lang="nl">Bestandsbeheerder</value>
         <value xml:lang="pt-BR">Gerenciador de arquivos</value>
-        <value xml:lang="ro">Gestiune Fisier</value>
+        <value xml:lang="ro">Manager de fișiere</value>
         <value xml:lang="ru">Менеджер файлов</value>
         <value xml:lang="th">จัดการไฟล์</value>
         <value xml:lang="vi">Quản lý tập tin</value>
@@ -1277,7 +1313,7 @@
         <value xml:lang="ja">が、あなたに次のメッセージのリンクを送信するようにリクエストしています:</value>
         <value xml:lang="nl">is aangevraagd dat we u deze link sturen met het bericht:</value>
         <value xml:lang="pt-BR">foi pedido que lhe enviássemos este link com a seguinte mensagem:</value>
-        <value xml:lang="ro">dupa cum ati cerut noi iti trimitem acest link cu urmatorul mesaj:</value>
+        <value xml:lang="ro">ne-a solicitat să vă trimitem acest link cu următorul mesaj:</value>
         <value xml:lang="ru">запрошен, мы посылаем вам эту ссылку со следующим сообщением:</value>
         <value xml:lang="th">ข้อความ</value>
         <value xml:lang="vi">đã yêu cầu chúng tôi gửi cho bạn liên kết này với thông điệp sau đây:</value>
@@ -1295,7 +1331,7 @@
         <value xml:lang="ja">上位(親)の記事から</value>
         <value xml:lang="nl">Van het bovenliggende artikel</value>
         <value xml:lang="pt-BR">Do artigo superior</value>
-        <value xml:lang="ro">De La Articolul Parinte</value>
+        <value xml:lang="ro">De La Articolul Părinte</value>
         <value xml:lang="ru">От родительской статьи</value>
         <value xml:lang="th">จากครอบครัว</value>
         <value xml:lang="vi">Từ bài viết cấp trên</value>
@@ -1313,7 +1349,7 @@
         <value xml:lang="ja">サイト(元):</value>
         <value xml:lang="nl">Van de website:</value>
         <value xml:lang="pt-BR">Do site:</value>
-        <value xml:lang="ro">De la Sit:</value>
+        <value xml:lang="ro">De la Site-ul:</value>
         <value xml:lang="ru">От сайта:</value>
         <value xml:lang="th">จากที่ทำงาน</value>
         <value xml:lang="vi">Từ trang thông tin</value>
@@ -1331,7 +1367,7 @@
         <value xml:lang="ja">ギフト金額:</value>
         <value xml:lang="nl">Geschenk saldo:</value>
         <value xml:lang="pt-BR">Quantidade de presente</value>
-        <value xml:lang="ro">Valoare Omagiu :</value>
+        <value xml:lang="ro">Valoare cadou:</value>
         <value xml:lang="ru">Сумма подарков:</value>
         <value xml:lang="th">จำนวนของขวัญ</value>
         <value xml:lang="vi">Giá trị quà tặng:</value>
@@ -1349,7 +1385,7 @@
         <value xml:lang="ja">ギフトカード送り主</value>
         <value xml:lang="nl">Geschenkkaart van</value>
         <value xml:lang="pt-BR">Cartão de presente de</value>
-        <value xml:lang="ro">Carte Omagiu de la</value>
+        <value xml:lang="ro">Card cadou de la</value>
         <value xml:lang="ru">Дисконтная карта от</value>
         <value xml:lang="th">รูปแบบบัตรของขวัญ</value>
         <value xml:lang="vi">Thẻ quà tặng từ</value>
@@ -1367,7 +1403,7 @@
         <value xml:lang="ja">お買い上げ後の残高:</value>
         <value xml:lang="nl">Het nieuwe saldo is :</value>
         <value xml:lang="pt-BR">Novo saldo de cartão de presente:</value>
-        <value xml:lang="ro">Noul bilant este :</value>
+        <value xml:lang="ro">Card cadou sold nou</value>
         <value xml:lang="ru">Новый баланс :</value>
         <value xml:lang="th">ยอดใหม่ของบัตรของขวัญ</value>
         <value xml:lang="vi">Tài khoản thẻ quà tặng mới</value>
@@ -1385,7 +1421,7 @@
         <value xml:lang="ja">注文は返金するように指定されています。</value>
         <value xml:lang="nl">Uw bestelling is gemarkeerd om terug te worden betaald.</value>
         <value xml:lang="pt-BR">Seu pedido foi marcado para ser reembolsado</value>
-        <value xml:lang="ro">Comanda ta a fost setata pentru a fi rambursata.</value>
+        <value xml:lang="ro">Card cadou rambursat</value>
         <value xml:lang="ru">Ваш заказ помечен как возвращенный.</value>
         <value xml:lang="th">ชดใช้บัตรของขวัญ</value>
         <value xml:lang="vi">Thẻ quà tặng được hoàn tiền</value>
@@ -1403,7 +1439,7 @@
         <value xml:lang="ja">がチャージされました。</value>
         <value xml:lang="nl">is heropgewaardeerd</value>
         <value xml:lang="pt-BR">Cartão de presente recarregado</value>
-        <value xml:lang="ro">a fost reincarcata.</value>
+        <value xml:lang="ro">Card cadou reîncărcat</value>
         <value xml:lang="ru">перезагружена.</value>
         <value xml:lang="th">ใส่บัตรของขวัญเพิ่ม</value>
         <value xml:lang="vi">Thẻ quà tặng đã được tải lại</value>
@@ -1421,7 +1457,7 @@
         <value xml:lang="ja">ギフトカードのチャージに失敗しました。レスポンスコード:</value>
         <value xml:lang="nl">Opwaarderen geschenkkaart mislukt</value>
         <value xml:lang="pt-BR">A recarga do cartão de presente falhou</value>
-        <value xml:lang="ro">Proces de Reincarcare Carte Omagiu Falita cu  cod de raspuns:</value>
+        <value xml:lang="ro">Reîncărcarea cardului cadou a eșuat</value>
         <value xml:lang="ru">Перезагрузка дисконтной карты не удалась с кодом ответа:</value>
         <value xml:lang="th">เกิดความผิดพลาดในการใส่บัตรของขวัญเพิ่ม</value>
         <value xml:lang="vi">Tải lại thông tin Thẻ quà tặng không thành công</value>
@@ -1439,7 +1475,7 @@
         <value xml:lang="ja">すべてのアイテムをギフト包装</value>
         <value xml:lang="nl">Geschenkverpakking voor alle items</value>
         <value xml:lang="pt-BR">Embrulhar todos os itens para presente</value>
-        <value xml:lang="ro">Omagiul Inglobeaza Toate Liniile</value>
+        <value xml:lang="ro">Ambaleaza toate articolele ca si cadou</value>
         <value xml:lang="ru">Подарочная упаковка для всех позиций</value>
         <value xml:lang="th">ห่อของขวัญทั้งหมด</value>
         <value xml:lang="vi">Gói tất cả hàng hóa</value>
@@ -1477,7 +1513,7 @@
         <value xml:lang="nl">Ga naar de lijst</value>
         <value xml:lang="pt-BR">Ir para a lista</value>
         <value xml:lang="pt-PT">Ir à Lista</value>
-        <value xml:lang="ro">Dute La Lista</value>
+        <value xml:lang="ro">Spre Listă</value>
         <value xml:lang="ru">Перейти к списку</value>
         <value xml:lang="th">ไปยังรายการ</value>
         <value xml:lang="vi">Tới danh sách</value>
@@ -1495,7 +1531,7 @@
         <value xml:lang="ja">高から低へ</value>
         <value xml:lang="nl">Hoog tot laag</value>
         <value xml:lang="pt-BR">Do maior para o menor</value>
-        <value xml:lang="ro">De Sus in Jos</value>
+        <value xml:lang="ro">De Sus în Jos</value>
         <value xml:lang="ru">От высокого к низкому</value>
         <value xml:lang="th">สูงถึงต่ำ</value>
         <value xml:lang="vi">Cao xuống thấp</value>
@@ -1531,7 +1567,7 @@
         <value xml:lang="ja">画像を中央上部に</value>
         <value xml:lang="nl">Plaatje gecentreerd erboven</value>
         <value xml:lang="pt-BR">Imagem centralizada acima</value>
-        <value xml:lang="ro">Imagine centrata dedesubt</value>
+        <value xml:lang="ro">Imagine centrată deasupra</value>
         <value xml:lang="ru">Изображение по центру ниже</value>
         <value xml:lang="th">จัดภาพไว้ด้านบนตรงกลาง</value>
         <value xml:lang="vi">Hình ảnh căn giữa</value>
@@ -1549,7 +1585,7 @@
         <value xml:lang="ja">ファイルから画像を中央上部に</value>
         <value xml:lang="nl">Plaatjes gecentreerd boven het bestand</value>
         <value xml:lang="pt-BR">Imagem centralizada acima do arquivo</value>
-        <value xml:lang="ro">Imagine centrata sub fisier</value>
+        <value xml:lang="ro">Imagine centrată deasupra fișierului</value>
         <value xml:lang="ru">Изображение из файла по центру ниже</value>
         <value xml:lang="th">จัดภาพไว้ตรงกลางบนไฟล์</value>
         <value xml:lang="vi">Hình ảnh căn giữa trên tệp tài liệu</value>
@@ -1567,7 +1603,7 @@
         <value xml:lang="ja">画像ファイル名</value>
         <value xml:lang="nl">Bestandsnaam van het plaatje</value>
         <value xml:lang="pt-BR">Nome do arquivo de imagem</value>
-        <value xml:lang="ro">Nume Fisier Imagine</value>
+        <value xml:lang="ro">Nume Fișier Imagine</value>
         <value xml:lang="ru">Имя файла изображения</value>
         <value xml:lang="th">ชื่อรูปภาพ</value>
         <value xml:lang="vi">Tên tệp hình ảnh</value>
@@ -1585,7 +1621,7 @@
         <value xml:lang="ja">画像情報</value>
         <value xml:lang="nl">Informatie over het plaatje</value>
         <value xml:lang="pt-BR">Dados da imagem</value>
-        <value xml:lang="ro">Informatii Imagine</value>
+        <value xml:lang="ro">Informații Imagine</value>
         <value xml:lang="ru">Информация об изображении</value>
         <value xml:lang="th">ข้อมูลรูปภาพ</value>
         <value xml:lang="vi">Thông tin hình ảnh</value>
@@ -1603,7 +1639,7 @@
         <value xml:lang="ja">画像は左、テキストは回り込む</value>
         <value xml:lang="nl">Plaatje links, de tekst wordt eromheen gegroepeerd</value>
         <value xml:lang="pt-BR">Imagem à esquerda, texto flutuante à direita</value>
-        <value xml:lang="ro">Imagine stanga, flux de text imrejur.</value>
+        <value xml:lang="ro">Imagine stânga, text împrejur.</value>
         <value xml:lang="ru">Изображение слева, текст обтекает вокруг.</value>
         <value xml:lang="th">รูปทางซ้าย</value>
         <value xml:lang="vi">Hình ảnh bên trái, chữ tràn xung quanh.</value>
@@ -1621,7 +1657,7 @@
         <value xml:lang="ja">回答:</value>
         <value xml:lang="nl">In antwoord op:</value>
         <value xml:lang="pt-BR">Em resposta a</value>
-        <value xml:lang="ro">In timpul raspunsului la:</value>
+        <value xml:lang="ro">Ca răspuns la:</value>
         <value xml:lang="ru">В ответ на:</value>
         <value xml:lang="th">คำตอบถึง</value>
         <value xml:lang="vi">Trong phản hồi cho</value>
@@ -1639,7 +1675,7 @@
         <value xml:lang="ja">通常使用</value>
         <value xml:lang="nl">Is standaard</value>
         <value xml:lang="pt-BR">É padrão</value>
-        <value xml:lang="ro">Este de Default</value>
+        <value xml:lang="ro">Este implicit</value>
         <value xml:lang="ru">по умолчанию</value>
         <value xml:lang="th">นี่คือค่าที่เลือกใช่หรือไม่</value>
         <value xml:lang="vi">Là mặc định</value>
@@ -1659,7 +1695,7 @@
         <value xml:lang="nl">Items van de boodschappenlijst</value>
         <value xml:lang="pt-BR">Itens da lista de compras</value>
         <value xml:lang="pt-PT">Itens de uma Lista de Compras; actualizar quantidades da lista na página</value>
-        <value xml:lang="ro">Linii dintr-o lista de cumparari; actualizeaza cantitatile de la lista din pagina</value>
+        <value xml:lang="ro">Articole din lista de cumpărături; actualizează cantitățile din lista de pe pagină</value>
         <value xml:lang="ru">Позиций из списка покупок; обновить количество со страницы списка</value>
         <value xml:lang="th">สินค้าจากรายการที่ซื้อ</value>
         <value xml:lang="vi">Hàng hóa từ Danh sách mua hàng</value>
@@ -1690,6 +1726,7 @@
         <value xml:lang="en">Language</value>
         <value xml:lang="ja">言語</value>
         <value xml:lang="nl">Taal</value>
+        <value xml:lang="ro">Limbă</value>
         <value xml:lang="vi">Ngôn ngữ</value>
         <value xml:lang="zh">语言</value>
         <value xml:lang="zh-TW">語言</value>
@@ -1724,7 +1761,7 @@
         <value xml:lang="ja">最近表示したコンテンツ</value>
         <value xml:lang="nl">Laatste content</value>
         <value xml:lang="pt-BR">último conteúdo</value>
-        <value xml:lang="ro">Ultimul  Continut</value>
+        <value xml:lang="ro">Ultimul  Conținut</value>
         <value xml:lang="ru">Последнее содержимое</value>
         <value xml:lang="th">หัวข้อสุดท้าย</value>
         <value xml:lang="vi">Nội dung mới xem</value>
@@ -1773,6 +1810,7 @@
     <property key="EcommerceLayeredNavigation">
         <value xml:lang="en">Layered Navigation</value>
         <value xml:lang="nl">Gelaagde navigatie</value>
+        <value xml:lang="ro">Navigare stratificată</value>
         <value xml:lang="zh">分层导航</value>
     </property>
     <property key="EcommerceLength">
@@ -1786,7 +1824,7 @@
         <value xml:lang="ja">長さ</value>
         <value xml:lang="nl">Lengte</value>
         <value xml:lang="pt-BR">Comprimento</value>
-        <value xml:lang="ro">Lungimea</value>
+        <value xml:lang="ro">Lungime</value>
         <value xml:lang="ru">Длина</value>
         <value xml:lang="th">ยาว</value>
         <value xml:lang="vi">Dài</value>
@@ -1798,6 +1836,7 @@
         <value xml:lang="fr">Limite :</value>
         <value xml:lang="ja">制限:</value>
         <value xml:lang="nl">Limiet:</value>
+        <value xml:lang="ro">Limită:</value>
         <value xml:lang="vi">Giới hạn:</value>
         <value xml:lang="zh">限制：</value>
         <value xml:lang="zh-TW">限制:</value>
@@ -1811,7 +1850,7 @@
         <value xml:lang="it">Link carte</value>
         <value xml:lang="ja">カードにリンク</value>
         <value xml:lang="nl">Kaarten linken</value>
-        <value xml:lang="ro">Link Carte</value>
+        <value xml:lang="ro">Conectați cardurile</value>
         <value xml:lang="ru">Ссылка на карты</value>
         <value xml:lang="th">เชื่อมกับบัตร</value>
         <value xml:lang="vi">Liên kết thẻ</value>
@@ -1831,7 +1870,7 @@
         <value xml:lang="nl">hoort niet bij u, probeer het opnieuw a.u.b.</value>
         <value xml:lang="pt-BR">Esta lista não lhe pertence, por favor tente novamente.</value>
         <value xml:lang="pt-PT">Não lhe pertence, por favor, tente outra vez</value>
-        <value xml:lang="ro">nu iti corespunde tie, te rugam sa mai incerci</value>
+        <value xml:lang="ro">nu îți corespunde ție, te rugăm sa mai încerci</value>
         <value xml:lang="ru">вам не принадлежит, пожалуйста попробуйте снова</value>
         <value xml:lang="th">รายการนี้ไม่ได้จัดอยู่ในประเภทนี้</value>
         <value xml:lang="vi">Danh sách không liên quan</value>
@@ -1851,7 +1890,7 @@
         <value xml:lang="nl">Boodschappenlijst artikelen</value>
         <value xml:lang="pt-BR">Itens da Lista de compras</value>
         <value xml:lang="pt-PT">Itens da Lista de Compras</value>
-        <value xml:lang="ro">Linii Liste Cumparaturi</value>
+        <value xml:lang="ro">Articole din lista de cumpărături</value>
         <value xml:lang="ru">Позиции списка покупок</value>
         <value xml:lang="th">รายการสิ่งของ</value>
         <value xml:lang="vi">Danh sách hàng hóa</value>
@@ -1870,7 +1909,7 @@
         <value xml:lang="nl">De totale prijs van deze lijst</value>
         <value xml:lang="pt-BR">Preço total da lista de compras</value>
         <value xml:lang="pt-PT">Preço Total Desta Lista De Compras</value>
-        <value xml:lang="ro">Pret Total Linii din aceasta Lista</value>
+        <value xml:lang="ro">Preț Total Articole din această Listă</value>
         <value xml:lang="ru">Общая цена позиций в этом списке</value>
         <value xml:lang="th">รายการรวมราคาสินค้า</value>
         <value xml:lang="vi">Tổng giá trị hàng hóa</value>
@@ -1890,7 +1929,7 @@
         <value xml:lang="nl">Lijstnaam</value>
         <value xml:lang="pt-BR">Nome da lista</value>
         <value xml:lang="pt-PT">Nome da Lista</value>
-        <value xml:lang="ro">Nume Lista</value>
+        <value xml:lang="ro">Nume Listă</value>
         <value xml:lang="ru">Имя списка</value>
         <value xml:lang="th">ชื่อรายการ</value>
         <value xml:lang="vi">Tên Danh sách</value>
@@ -1908,7 +1947,7 @@
         <value xml:lang="ja">注意: メール連絡リストを申し込むと、承諾の確認および申し込み確認のリンク先がメールで届きます。リンクの代わりの方法として承諾の確認コードをここで入力することもできます。</value>
         <value xml:lang="nl">Attentie: Wanneer u zich abonneert op een nieuwsbrief ontvangt u een email met daarin een verificatie code en een link naar de pagina waar u deze code kunt ingeven ter controle. U kunt de verificatie code ook hier ingeven.</value>
         <value xml:lang="pt-BR">Atenção: quando você se inscrever em uma lista de contatos de emails você receberá um email com um link de verificação e um código. Alternativamente você pode digitar o código aqui.</value>
-        <value xml:lang="ro">NOTA: Dupa ce ai subscris un email la lista de contact tu vei primi un email cu un cod de verificare si un link pentru verificarea subinscrierii tale. In alternativa la link tu poti sa introduci codul tau de verificare aici.</value>
+        <value xml:lang="ro">NOTĂ: Când vă abonați la o listă de e-mail, veți primi un e-mail cu un cod de verificare și un link pentru verificarea abonarii. Ca alternativă la link, puteți introduce codul de verificare aici.</value>
         <value xml:lang="ru">ПРИМЕЧАНИЕ: В процессе подписки на список рассылки вы получите сообщение с проверочным кодом и ссылкой на страницу подтверждения. В качестве альтернативы, вы можете ввести этот код здесь.</value>
         <value xml:lang="th">รายการข้อสังเกต</value>
         <value xml:lang="vi">LƯU Ý: Khi bạn đăng ký địa chỉ thư điện tử liên lạc bạn sẽ nhận được một thư điện tử với lựa chọn là mã xác nhận hoặc một liên kết để xác nhận việc Bảo lãnh bán hàng. Hoặc bạn sử dụng liên kết mà bạn có thể nhập mã xác nhận tại đây.</value>
@@ -1923,6 +1962,7 @@
         <value xml:lang="ja">位置</value>
         <value xml:lang="nl">Locatie</value>
         <value xml:lang="pt-BR">Local</value>
+        <value xml:lang="ro">Locaţie</value>
         <value xml:lang="vi">Địa điểm</value>
         <value xml:lang="zh">地点</value>
         <value xml:lang="zh-TW">地點</value>
@@ -1937,7 +1977,7 @@
         <value xml:lang="ja">(投稿はログインしてください)</value>
         <value xml:lang="nl">(U moet ingelogd zijn om een bericht toe te voegen)</value>
         <value xml:lang="pt-BR">(Você deve registrar-se para publicar algo)</value>
-        <value xml:lang="ro">(Trebuie sa te loghezi la Posta)</value>
+        <value xml:lang="ro">(Trebuie să fii logat ca să postezi)</value>
         <value xml:lang="ru">(Вы должны зарегистрироваться, чтобы иметь возможность писать самому)</value>
         <value xml:lang="th">บันทึกเพื่อแจ้ง</value>
         <value xml:lang="vi">(Bạn phải đăng nhập trước khi đăng bài)</value>
@@ -1973,7 +2013,7 @@
         <value xml:lang="ja">パスワードを忘れた場合は、いつでも新しいパスワードがリクエスト可能です。</value>
         <value xml:lang="nl">Als u uw wachtwoord vergeet kunt u altijd een nieuw wachtwoord aanvragen.</value>
         <value xml:lang="pt-BR">Se você perder sua senha, você pode requisitar uma nova a qualquer momento</value>
-        <value xml:lang="ro">Daca nu iti mai amintesti parola, poti oricand sa ceri una noua.</value>
+        <value xml:lang="ro">Dacă nu îți mai amintești parola, poți oricând să ceri una nouă.</value>
         <value xml:lang="ru">Если вы забыли пароль, можете запросить новый в любое время.</value>
         <value xml:lang="th">ลืมรหัสผ่าน</value>
         <value xml:lang="vi">Trường hợp quên mật khẩu, bạn có thể yêu cầu một mật khẩu mới bất kỳ khi nào.</value>
@@ -1991,7 +2031,7 @@
         <value xml:lang="ja">低から高へ</value>
         <value xml:lang="nl">Van laag tot hoog</value>
         <value xml:lang="pt-BR">Do menor para o maior</value>
-        <value xml:lang="ro">De Jos in Sus </value>
+        <value xml:lang="ro">De Jos în Sus</value>
         <value xml:lang="ru">От меньшего к большему</value>
         <value xml:lang="th">ต่ำถึงสูง</value>
         <value xml:lang="vi">Thấp đến Cao</value>
@@ -2009,7 +2049,7 @@
         <value xml:lang="ja">ロイヤリティポイント</value>
         <value xml:lang="nl">Loyaliteitspunten</value>
         <value xml:lang="pt-BR">Pontos de fidelidade</value>
-        <value xml:lang="ro">Puncte de Fidelitate </value>
+        <value xml:lang="ro">Puncte de Fidelitate</value>
         <value xml:lang="ru">Точки лояльности</value>
         <value xml:lang="th">เห็นด้วย</value>
         <value xml:lang="vi">Điểm gắn bó</value>
@@ -2025,6 +2065,7 @@
         <value xml:lang="ja">住所の管理</value>
         <value xml:lang="nl">Adressen beheren</value>
         <value xml:lang="pt-BR">Gerenciar endereços</value>
+        <value xml:lang="ro">Gestionați adresele</value>
         <value xml:lang="vi">Quản lý địa chỉ</value>
         <value xml:lang="zh">管理地址</value>
         <value xml:lang="zh-TW">管理位址</value>
@@ -2039,7 +2080,7 @@
         <value xml:lang="ja">申し訳ございません。指定製品ID</value>
         <value xml:lang="nl">Excuses, het gespecificeerde product</value>
         <value xml:lang="pt-BR">Desculpe, parece que o ID do produto especificado</value>
-        <value xml:lang="ro">Imi pare rau, pare ca produsul specificat </value>
+        <value xml:lang="ro">Îmi pare rău, se pare că produsul specificat</value>
         <value xml:lang="ru">Sorry, it appears that the specified product ID</value>
         <value xml:lang="th">ขอโทษค่ะ , มันปรากฏเฉพาะรหัสสินค้า</value>
         <value xml:lang="vi">Rất tiếc, Id sản phẩm bạn chọn bị trùng với sản phẩm đã có</value>
@@ -2056,7 +2097,7 @@
         <value xml:lang="ja">あなたが所有したものではありません</value>
         <value xml:lang="nl">niet bij u hoort.</value>
         <value xml:lang="pt-BR">não lhe pertence</value>
-        <value xml:lang="ro">nu iti corespunde tie.</value>
+        <value xml:lang="ro">nu îți corespunde ție.</value>
         <value xml:lang="ru">не пренадлежит вам.</value>
         <value xml:lang="th">ไม่เป็นส่วนหนึ่งของคุณ</value>
         <value xml:lang="vi">không thuộc về bạn.</value>
@@ -2073,7 +2114,7 @@
         <value xml:lang="ja">新規請求先住所を選択:</value>
         <value xml:lang="nl">Kies een nieuw factuuradres:</value>
         <value xml:lang="pt-BR">Selecione num novo endereço de cobrança:</value>
-        <value xml:lang="ro">Selectioneaza o Noua Adresa Facturare:</value>
+        <value xml:lang="ro">Selectează o Nouă Adresă de Facturare:</value>
         <value xml:lang="ru">Выберите новый платежный адрес:</value>
         <value xml:lang="th">เลือกที่อยู่ใบแจ้งค่าบริการใหม่ :</value>
         <value xml:lang="vi">Lựa chọn địa chỉ thanh toán mới:</value>
@@ -2090,7 +2131,7 @@
         <value xml:lang="ja">フォーラムのメッセージ一覧:</value>
         <value xml:lang="nl">Berichtenlijst voor forum</value>
         <value xml:lang="pt-BR">Lista de mensagens para o Forum</value>
-        <value xml:lang="ro">Lista Messaje pentru forum:</value>
+        <value xml:lang="ro">Listă Messaje pentru forum:</value>
         <value xml:lang="ru">Список сообщений для форума:</value>
         <value xml:lang="th">รายการข้อความที่แสดงความคิดเห็น</value>
         <value xml:lang="vi">Danh sách thông điệp cho Diễn đàn</value>
@@ -2106,6 +2147,7 @@
         <value xml:lang="ja">支払方法を選択してください</value>
         <value xml:lang="nl">Selecteer a.u.b. een betaalwijze</value>
         <value xml:lang="pt-BR">Por favor, selecione o método de pagamento</value>
+        <value xml:lang="ro">Vă rugăm să selectați Metoda de plată</value>
         <value xml:lang="ru">Пожалуйста выберите метод оплаты</value>
         <value xml:lang="th">กรุณาเลือกวิธีการชำระเงิน</value>
         <value xml:lang="vi">Vui lòng lựa chọn phương thức thanh toán</value>
@@ -2121,6 +2163,7 @@
         <value xml:lang="ja">発送方法を選択してください</value>
         <value xml:lang="nl">Selecteer a.u.b. een verzendmethode</value>
         <value xml:lang="pt-BR">Por favor, selecione o método de pagamento</value>
+        <value xml:lang="ro">Vă rugăm să selectați metoda de livrare</value>
         <value xml:lang="ru">Пожалуйста выберите метод доставки</value>
         <value xml:lang="th">กรุณาเลือกวิธีการขนส่งสินค้า</value>
         <value xml:lang="vi">Vui lòng lựa chọn phương thức giao hàng</value>
@@ -2131,6 +2174,7 @@
         <value xml:lang="en">Modified Date</value>
         <value xml:lang="ja">更新日</value>
         <value xml:lang="nl">Datum wijziging</value>
+        <value xml:lang="ro">Data modificată</value>
         <value xml:lang="vi">Ngày chỉnh sửa</value>
         <value xml:lang="zh">修改日期</value>
         <value xml:lang="zh-TW">修改日期</value>
@@ -2158,6 +2202,7 @@
         <value xml:lang="it">Mesi all'indirizzo non è un numero valido: ${parameters.monthsAtAddress}</value>
         <value xml:lang="ja">住所が有効でない月数: ${parameters.monthsAtAddress}</value>
         <value xml:lang="nl">Maanden op adres niet correct: ${parameters.monthsAtAddress}</value>
+        <value xml:lang="ro">Luni la adresa nu este un număr valid: ${parameters.monthsAtAddress}</value>
         <value xml:lang="vi">Số tháng tại địa chỉ không là số hợp lệ: ${parameters.monthsAtAddress}</value>
         <value xml:lang="zh">在地址的月数不是一个有效数字：${parameters.monthsAtAddress}</value>
         <value xml:lang="zh-TW">在位址的月數不是一個有效數字:${parameters.monthsAtAddress}</value>
@@ -2167,6 +2212,7 @@
         <value xml:lang="it">Mesi come impiegato non è un numero valido: ${parameters.monthsWithEmployer}</value>
         <value xml:lang="ja">雇用者が有効でない月数: ${parameters.monthsWithEmployer}</value>
         <value xml:lang="nl">Maanden bij werkgever niet correct: ${parameters.monthsWithEmployer}</value>
+        <value xml:lang="ro">Luni cu Angajatorul nu a fost un număr valid: ${parameters.monthsWithEmployer}</value>
         <value xml:lang="vi">Số tháng với nhân viên không là số hợp lệ: ${parameters.monthsWithEmployer}</value>
         <value xml:lang="zh">雇主的月数不是一个有效数字：${parameters.monthsWithEmployer}</value>
         <value xml:lang="zh-TW">雇主的月數不是一個有效數字:${parameters.monthsWithEmployer}</value>
@@ -2180,6 +2226,7 @@
         <value xml:lang="ja">私のアカウント</value>
         <value xml:lang="nl">Mijn account</value>
         <value xml:lang="pt-BR">Minha conta</value>
+        <value xml:lang="ro">Contul meu</value>
         <value xml:lang="vi">Tài khoản của tôi</value>
         <value xml:lang="zh">我的账户</value>
         <value xml:lang="zh-TW">我的帳戶</value>
@@ -2193,6 +2240,7 @@
         <value xml:lang="ja">これを私の通常の請求先住所にする</value>
         <value xml:lang="nl">Van dit adres het standaard factuuradres maken</value>
         <value xml:lang="pt-BR">Faça deste o meu endereço padrão para cobrança</value>
+        <value xml:lang="ro">Setati ca adresă de facturare implicită</value>
         <value xml:lang="vi">Cũng là địa chỉ mặc định ghi hóa đơn</value>
         <value xml:lang="zh">把这个设置为我的缺省寄账单地址</value>
         <value xml:lang="zh-TW">把此項設為我的預設帳單位址</value>
@@ -2206,6 +2254,7 @@
         <value xml:lang="ja">これを私の通常の発送先住所にする</value>
         <value xml:lang="nl">Van dit adres het standaard verzendadres maken</value>
         <value xml:lang="pt-BR">Faça deste o meu endereço padrão para envio</value>
+        <value xml:lang="ro">Setați ca adresă de livrare implicită</value>
         <value xml:lang="vi">Cũng là địa chỉ mặc định nhận hàng</value>
         <value xml:lang="zh">把这个设置为我的缺省送货地址</value>
         <value xml:lang="zh-TW">把此項設為我的預設貨運位址</value>
@@ -2221,7 +2270,7 @@
         <value xml:lang="ja">日数</value>
         <value xml:lang="nl">Aantal dagen</value>
         <value xml:lang="pt-BR">Nº de dias</value>
-        <value xml:lang="ro">N. de zile</value>
+        <value xml:lang="ro">Nr. de zile</value>
         <value xml:lang="ru">Кол-во дней</value>
         <value xml:lang="th">จำนวนวัน</value>
         <value xml:lang="vi">Số ngày</value>
@@ -2239,7 +2288,7 @@
         <value xml:lang="ja">人数</value>
         <value xml:lang="nl">Aantal personen</value>
         <value xml:lang="pt-BR">Nº de pessoas</value>
-        <value xml:lang="ro">N. de persoane</value>
+        <value xml:lang="ro">Nr. de persoane</value>
         <value xml:lang="ru">Кол-во персон</value>
         <value xml:lang="th">จำนวนคน</value>
         <value xml:lang="vi">Số người</value>
@@ -2257,7 +2306,7 @@
         <value xml:lang="ja">ネストしたコンテンツ</value>
         <value xml:lang="nl">Ingesloten content</value>
         <value xml:lang="pt-BR">Conteúdo incluso</value>
-        <value xml:lang="ro">Continut Inglobat.</value>
+        <value xml:lang="ro">Conținut Înglobat.</value>
         <value xml:lang="ru">Вложенный контент.</value>
         <value xml:lang="th">หัวข้อที่อยู่</value>
         <value xml:lang="vi">Nội dung được lồng vào</value>
@@ -2275,7 +2324,7 @@
         <value xml:lang="ja">新規クレジットカード</value>
         <value xml:lang="nl">Nieuwe creditcard</value>
         <value xml:lang="pt-BR">Novo cartão de crédito</value>
-        <value xml:lang="ro">Noua Carte de Credit</value>
+        <value xml:lang="ro">Card de Credit nou</value>
         <value xml:lang="ru">Новая кредитная карта</value>
         <value xml:lang="th">บัตรเครดิตใหม่</value>
         <value xml:lang="vi">Thêm thông tin thẻ tín dụng</value>
@@ -2293,7 +2342,7 @@
         <value xml:lang="ja">新規電子取引(EFT)アカウント</value>
         <value xml:lang="nl">Nieuwe bankrekening</value>
         <value xml:lang="pt-BR">Nova conta EFT</value>
-        <value xml:lang="ro">Nou Cont EFT</value>
+        <value xml:lang="ro">Cont nou de transfer electronic</value>
         <value xml:lang="ru">Новый текущий счет</value>
         <value xml:lang="th">บัญชีธนาคารใหม่</value>
         <value xml:lang="vi">Tài khoản thanh toán điện tử mới</value>
@@ -2310,7 +2359,7 @@
         <value xml:lang="ja">新規一覧申込</value>
         <value xml:lang="nl">Op nieuwe lijst abonneren</value>
         <value xml:lang="pt-BR">Nova assinatura de lista</value>
-        <value xml:lang="ro">Noua Lista Subscriere </value>
+        <value xml:lang="ro">Listă Nouă Subscripție</value>
         <value xml:lang="ru">Новая подписка на рассылку</value>
         <value xml:lang="th">รายการสั่งซื้อใหม่</value>
         <value xml:lang="vi">Danh sách Bảo lãnh bán hàng mới</value>
@@ -2327,7 +2376,7 @@
         <value xml:lang="ja">ソフトウェア製品はありません</value>
         <value xml:lang="nl">Geen digitale producten gevonden</value>
         <value xml:lang="pt-BR">Nenhum produto digital encontrado</value>
-        <value xml:lang="ro">Nici-un Produs Digital Gasit</value>
+        <value xml:lang="ro">Niciun Produs Digital Găsit</value>
         <value xml:lang="ru">Нет цифровых продуктов</value>
         <value xml:lang="th">ไม่พบสินค้าดิจิตัลที่ค้นหา</value>
         <value xml:lang="vi">Không tìm thấy sản phẩm</value>
@@ -2345,7 +2394,7 @@
         <value xml:lang="ja">ファイルはありません</value>
         <value xml:lang="nl">U heeft geen bestanden</value>
         <value xml:lang="pt-BR">Nenhum arquivo</value>
-        <value xml:lang="ro">Nu ai fisiere.</value>
+        <value xml:lang="ro">Nu ai fișiere.</value>
         <value xml:lang="ru">У вас нет файлов.</value>
         <value xml:lang="th">ไม่มีไฟล์</value>
         <value xml:lang="vi">Không có tập tin</value>
@@ -2363,7 +2412,7 @@
         <value xml:lang="ja">ギフト包装はありません</value>
         <value xml:lang="nl">Geen geschenkverpakking</value>
         <value xml:lang="pt-BR">Sem embrulho para presente</value>
-        <value xml:lang="ro">Nici-un Omagiu</value>
+        <value xml:lang="ro">Fără ambalaj cadou</value>
         <value xml:lang="ru">No Gift Wrap</value>
         <value xml:lang="th">ไม่ห่อของขวัญ</value>
         <value xml:lang="vi">Không gói quà</value>
@@ -2400,7 +2449,7 @@
         <value xml:lang="nl">Geen moeder</value>
         <value xml:lang="pt-BR">Não há superior</value>
         <value xml:lang="pt-PT">Sem Semelhança</value>
-        <value xml:lang="ro">Nici-un Parinte </value>
+        <value xml:lang="ro">Niciun Părinte</value>
         <value xml:lang="ru">Нет родителя</value>
         <value xml:lang="th">กำพร้า</value>
         <value xml:lang="vi">Không có cấp trên</value>
@@ -2417,7 +2466,7 @@
         <value xml:lang="ja">製品店舗はありません</value>
         <value xml:lang="nl">Er is geen winkel voor deze website, kijk naar de instellingen.</value>
         <value xml:lang="pt-BR">Não há loja associada a est produto</value>
-        <value xml:lang="ro">Nu este nici un ProductStore pentru acest WebSite; Controlati Setarile.</value>
+        <value xml:lang="ro">Nu există nici un Magazin de produse pentru acest WebSite; Verificați Setările.</value>
         <value xml:lang="ru">Нет существует ProductStore для этого сайта; Проверьте настройки.</value>
         <value xml:lang="th">ไม่มีสินค้าในคลังสินค้า</value>
         <value xml:lang="vi">Không có cửa hàng</value>
@@ -2435,7 +2484,7 @@
         <value xml:lang="ja">プロモーションカテゴリはありません</value>
         <value xml:lang="nl">Geen promotie categorie gevonden</value>
         <value xml:lang="pt-BR">Não há promoções disponíveis</value>
-        <value xml:lang="ro">Nici-o Categorie PROMOTIONALA gasita pentru CATALOG</value>
+        <value xml:lang="ro">Nici o Categorie PROMOȚIONALĂ găsită</value>
         <value xml:lang="ru">В каталоге не найдена акционная категория</value>
         <value xml:lang="th">ไม่มีโปรโมชั่นในหมวดหมู่นี้</value>
         <value xml:lang="vi">Không có Phân loại Quản lý KHUYẾN MẠI cho Phân loại Trình diễn</value>
@@ -2455,7 +2504,7 @@
         <value xml:lang="nl">Er zijn geen boodschappenlijsten om te selecteren, maak een nieuwe aan</value>
         <value xml:lang="pt-BR">Nenhuma lista de compras selecionada, crie uma nova</value>
         <value xml:lang="pt-PT">Sem listas de compras para seleccionar,por favor, crie uma nova</value>
-        <value xml:lang="ro">Nici-o lista de cumparare selectionata, creaza una noua</value>
+        <value xml:lang="ro">Nu există liste de cumpărături, creați una nouă</value>
         <value xml:lang="ru">Нет выбранных списков покупок, создать новый</value>
         <value xml:lang="th">ไม่มีการสร้างรายการซื้อ</value>
         <value xml:lang="vi">Hiện tại bạn chưa có Danh sách mua hàng nào, mời bạn tham gia mua hàng</value>
@@ -2507,6 +2556,7 @@
         <value xml:lang="ja">存在しません</value>
         <value xml:lang="nl">Bestaat niet</value>
         <value xml:lang="pt-BR">Não existe</value>
+        <value xml:lang="ro">Nu există</value>
         <value xml:lang="vi">Không tồn tại</value>
         <value xml:lang="zh">不存在</value>
         <value xml:lang="zh-TW">不存在</value>
@@ -2521,7 +2571,7 @@
         <value xml:lang="ja">まだ不明です</value>
         <value xml:lang="nl">Nog onbekend</value>
         <value xml:lang="pt-BR">Ainda desconhecido</value>
-        <value xml:lang="ro">Nu este inca cunoscut</value>
+        <value xml:lang="ro">Nu este încă cunoscut</value>
         <value xml:lang="ru">Еще не известный</value>
         <value xml:lang="th">ยังไม่ทราบ</value>
         <value xml:lang="vi">Không được hiểu</value>
@@ -2537,6 +2587,7 @@
         <value xml:lang="ja">1ﾍﾟｰｼﾞﾁｪｯｸｱｳﾄ</value>
         <value xml:lang="nl">Bestellen in 1 stap</value>
         <value xml:lang="pt-BR">Finalização da compra em uma página</value>
+        <value xml:lang="ro">Finalizează comanda pe o pagină</value>
         <value xml:lang="vi">Thanh toán luôn</value>
         <value xml:lang="zh">一页结账</value>
         <value xml:lang="zh-TW">單頁結帳</value>
@@ -2553,7 +2604,7 @@
         <value xml:lang="nl">Bevestiging bestelling</value>
         <value xml:lang="pt-BR">Confirmação de pedido</value>
         <value xml:lang="pt-PT">Confirmação de Encomenda</value>
-        <value xml:lang="ro">Confirma Comanda</value>
+        <value xml:lang="ro">Confirmă Comanda</value>
         <value xml:lang="ru">Подтверждение заказа</value>
         <value xml:lang="th">การยืนยันการสั่งสินค้า</value>
         <value xml:lang="vi">Xác nhận đặt hàng</value>
@@ -2573,7 +2624,7 @@
         <value xml:lang="nl">Bestelhistorie</value>
         <value xml:lang="pt-BR">Histórico de pedidos</value>
         <value xml:lang="pt-PT">Histórico De Encomendas</value>
-        <value xml:lang="ro">Istoric Comenzi </value>
+        <value xml:lang="ro">Istoric Comenzi</value>
         <value xml:lang="ru">История заказа</value>
         <value xml:lang="th">ข้อมูลรายการที่สั่งซื้อ</value>
         <value xml:lang="vi">Lịch sử đặt hàng</value>
@@ -2591,7 +2642,7 @@
         <value xml:lang="ja">/ 最近</value>
         <value xml:lang="nl">bestelling(en) in de laatste</value>
         <value xml:lang="pt-BR">Pedidos nos últimos</value>
-        <value xml:lang="ro">comenzi in ultimele</value>
+        <value xml:lang="ro">comenzi în ultimele</value>
         <value xml:lang="ru">последний заказ(ы)</value>
         <value xml:lang="th">รายการสั่งซื้อสุดท้าย</value>
         <value xml:lang="vi">đặt hàng trong quá khứ</value>
@@ -2607,6 +2658,7 @@
         <value xml:lang="ja">注文は有効ではありません</value>
         <value xml:lang="nl">Bestelling niet actief</value>
         <value xml:lang="pt-BR">Pedido não ativo</value>
+        <value xml:lang="ro">Comanda inactivă</value>
         <value xml:lang="th">รายการสั่งซื้อสินค้าไม่ทำงาน</value>
         <value xml:lang="vi">Đặt hàng không hoạt động</value>
         <value xml:lang="zh">订单没有激活</value>
@@ -2616,6 +2668,7 @@
         <value xml:lang="en">Owner</value>
         <value xml:lang="ja">所有者</value>
         <value xml:lang="nl">Eigenaar</value>
+        <value xml:lang="ro">Proprietar</value>
         <value xml:lang="vi">Chủ sở hữu</value>
         <value xml:lang="zh">拥有者</value>
         <value xml:lang="zh-TW">擁有者</value>
@@ -2630,7 +2683,7 @@
         <value xml:lang="ja">所有部門</value>
         <value xml:lang="nl">Afdelingseigendom</value>
         <value xml:lang="pt-BR">Departamento proprietário</value>
-        <value xml:lang="ro">Divizie Posedata</value>
+        <value xml:lang="ro">Departamentul proprietar</value>
         <value xml:lang="ru">Отдел владелец</value>
         <value xml:lang="th">ของแผนก</value>
         <value xml:lang="vi">Phòng ban sở hữu</value>
@@ -2649,7 +2702,7 @@
         <value xml:lang="nl">Afgeleidenlijst</value>
         <value xml:lang="pt-BR">Lista superior</value>
         <value xml:lang="pt-PT">Lista de Semelhantes</value>
-        <value xml:lang="ro">Lista Parinte</value>
+        <value xml:lang="ro">Listă Părinte</value>
         <value xml:lang="ru">Родительский список</value>
         <value xml:lang="th">รายชื่อกลุ่ม</value>
         <value xml:lang="vi">Danh sách cấp trên</value>
@@ -2667,7 +2720,7 @@
         <value xml:lang="ja">登録時に設定したパスワード</value>
         <value xml:lang="nl">Met het wachtwoord dat u heeft ingegeven bij de registratie</value>
         <value xml:lang="pt-BR">Com a senha criada durante o registro</value>
-        <value xml:lang="ro">cu parola pe care tu o setezi in timpul inregistrarii.</value>
+        <value xml:lang="ro">Cu parola pe care o setezi în timpul înregistrării.</value>
         <value xml:lang="ru">С паролем который вы назначили в процессе регистрации.</value>
         <value xml:lang="th">รหัสผ่าน</value>
         <value xml:lang="vi">với mật khẩu bạn cài đặt trong quá trình đăng ký.</value>
@@ -2683,6 +2736,7 @@
         <value xml:lang="ja">パスワード</value>
         <value xml:lang="nl">Wachtwoord is</value>
         <value xml:lang="pt-BR">A senha é:</value>
+        <value xml:lang="ro">parola este</value>
         <value xml:lang="th">รหัสผ่านคือ</value>
         <value xml:lang="vi">mật khẩu là</value>
         <value xml:lang="zh">密码是</value>
@@ -2697,6 +2751,7 @@
         <value xml:lang="ja">しばらくお待ちください</value>
         <value xml:lang="nl">Even wachten a.u.b.</value>
         <value xml:lang="pt-BR">Por favor, aguarde</value>
+        <value xml:lang="ro">Vă rugăm așteptați</value>
         <value xml:lang="vi">Vui lòng chờ</value>
         <value xml:lang="zh">请等待</value>
         <value xml:lang="zh-TW">請等待</value>
@@ -2712,7 +2767,7 @@
         <value xml:lang="ja">ポイント。注文回数</value>
         <value xml:lang="nl">punten van</value>
         <value xml:lang="pt-BR">Pontos de</value>
-        <value xml:lang="ro">puncte de</value>
+        <value xml:lang="ro">puncte de la</value>
         <value xml:lang="ru">points from</value>
         <value xml:lang="th">ความคิดเห็นจาก</value>
         <value xml:lang="vi">Điểm từ</value>
@@ -2732,7 +2787,7 @@
         <value xml:lang="nl">Anoniem ingeven</value>
         <value xml:lang="pt-BR">Publicar como anônimo</value>
         <value xml:lang="pt-PT">Correio Anónimo</value>
-        <value xml:lang="ro">Posta Anonima</value>
+        <value xml:lang="ro">Postare Anonimă</value>
         <value xml:lang="ru">Послать анонимно</value>
         <value xml:lang="th">ไม่ระบุชื่อผู้แจ้ง</value>
         <value xml:lang="vi">Bài đăng của khách giấu tên</value>
@@ -2752,7 +2807,7 @@
         <value xml:lang="nl">Prijs</value>
         <value xml:lang="pt-BR">Preço</value>
         <value xml:lang="pt-PT">Preço</value>
-        <value xml:lang="ro">Pret</value>
+        <value xml:lang="ro">Preț</value>
         <value xml:lang="ru">Цена</value>
         <value xml:lang="th">ราคา</value>
         <value xml:lang="vi">Giá</value>
@@ -2764,6 +2819,7 @@
         <value xml:lang="ja">価格レンジ</value>
         <value xml:lang="nl">Prijs range</value>
         <value xml:lang="pt-BR">Faixa de preços</value>
+        <value xml:lang="ro">Interval de prețuri</value>
         <value xml:lang="vi">Khoảng giá</value>
         <value xml:lang="zh">价格范围</value>
         <value xml:lang="zh-TW">價格範圍</value>
@@ -2777,6 +2833,7 @@
         <value xml:lang="ja">主請求先住所</value>
         <value xml:lang="nl">Primair factuuradres</value>
         <value xml:lang="pt-BR">Endereço de cobrança primário</value>
+        <value xml:lang="ro">Adresa principală de facturare</value>
         <value xml:lang="vi">Địa chỉ ghi hóa đơn ưu tiên</value>
         <value xml:lang="zh">首选寄账单地址</value>
         <value xml:lang="zh-TW">首選帳單位址</value>
@@ -2790,6 +2847,7 @@
         <value xml:lang="ja">主発送先住所</value>
         <value xml:lang="nl">Primair verzendadres</value>
         <value xml:lang="pt-BR">Endereço de envio primário</value>
+        <value xml:lang="ro">Adresa de livrare principală</value>
         <value xml:lang="vi">Địa chỉ giao hàng ưu tiên</value>
         <value xml:lang="zh">首选送货地址</value>
         <value xml:lang="zh-TW">首選送貨位址</value>
@@ -2802,6 +2860,7 @@
         <value xml:lang="ja">製品は設定されていません</value>
         <value xml:lang="nl">Product niet geconfigureerd</value>
         <value xml:lang="pt-BR">Produto não configurado</value>
+        <value xml:lang="ro">Produsul nu este configurat</value>
         <value xml:lang="vi">Sản phẩm chưa được cấu hình</value>
         <value xml:lang="zh">产品没有配置</value>
         <value xml:lang="zh-TW">產品沒有配置</value>
@@ -2830,6 +2889,7 @@
         <value xml:lang="fr">Étiquettes</value>
         <value xml:lang="ja">製品タグ</value>
         <value xml:lang="nl">Tags</value>
+        <value xml:lang="ro">Etichete produs</value>
         <value xml:lang="vi">Các đánh dấu (tag) sản phẩm</value>
         <value xml:lang="zh">产品标签</value>
         <value xml:lang="zh-TW">產品標籤</value>
@@ -2840,6 +2900,7 @@
         <value xml:lang="fr">Cette étiquette a déjà été ajoutée pour ce produit</value>
         <value xml:lang="ja">他の人がこの製品に同じタグ付け</value>
         <value xml:lang="nl">Andere shoppers gaven deze tags</value>
+        <value xml:lang="ro">Alte persoane au marcat acest produs cu aceste etichete</value>
         <value xml:lang="vi">Người khác đã đánh dấu sản phẩm này với các đánh dấu</value>
         <value xml:lang="zh">其他人使用这些标签来标志这个产品</value>
         <value xml:lang="zh-TW">其他人使用這些標籤來標誌這個產品</value>
@@ -2857,7 +2918,7 @@
         <value xml:lang="nl">Promoties; hoeveelheden kunnen niet worden aangepast</value>
         <value xml:lang="pt-BR">Itens promocionais</value>
         <value xml:lang="pt-PT">Itens em promoção; as quantidades não podem ser alteradas</value>
-        <value xml:lang="ro">Linii Promotie; Cantitatile nu pot sa fie modificate</value>
+        <value xml:lang="ro">Articole Promoționale; Cantitățile nu pot fi modificate</value>
         <value xml:lang="ru">Акционные позиции; количество не может быть изменено</value>
         <value xml:lang="th">สินค้าในโปรโมชั่น</value>
         <value xml:lang="vi">Hàng hóa khuyến mại</value>
@@ -2912,7 +2973,7 @@
         <value xml:lang="ja">評価</value>
         <value xml:lang="nl">Waardering</value>
         <value xml:lang="pt-BR">Taxa</value>
-        <value xml:lang="ro">Pozitie</value>
+        <value xml:lang="ro">Rată</value>
         <value xml:lang="ru">Рейтинг</value>
         <value xml:lang="th">อัตรา</value>
         <value xml:lang="vi">Đánh giá</value>
@@ -2932,7 +2993,7 @@
         <value xml:lang="nl">Waardering (1-5; 5 is het beste)</value>
         <value xml:lang="pt-BR">Nota (de 1 a 5)</value>
         <value xml:lang="pt-PT">Classe (1-5; 5 para o melhor)</value>
-        <value xml:lang="ro">Pozitia(1-5; 5 este cea mai buna )</value>
+        <value xml:lang="ro">Recenzie(1-5; 5 este cea mai bună)</value>
         <value xml:lang="ru">Рейтинг (1-5; 5 лучший)</value>
         <value xml:lang="th">การประเมิณ (1-5; 5 คุณสมบัติดีที่สุด)</value>
         <value xml:lang="vi">Dự kiến</value>
@@ -2949,7 +3010,7 @@
         <value xml:lang="ja">読む</value>
         <value xml:lang="nl">Lees</value>
         <value xml:lang="pt-BR">Ler</value>
-        <value xml:lang="ro">Citeste</value>
+        <value xml:lang="ro">Citește</value>
         <value xml:lang="ru">Читать</value>
         <value xml:lang="th">อ่าน</value>
         <value xml:lang="vi">Đọc</value>
@@ -2966,7 +3027,7 @@
         <value xml:lang="ja">メッセージを読む</value>
         <value xml:lang="nl">Lees bericht</value>
         <value xml:lang="pt-BR">Ler mensagem</value>
-        <value xml:lang="ro">Citeste Mesaj</value>
+        <value xml:lang="ro">Citește Mesaj</value>
         <value xml:lang="ru">Читать сообщение</value>
         <value xml:lang="th">อ่านข้อความ</value>
         <value xml:lang="vi">Đọc tin nhắn</value>
@@ -2987,7 +3048,7 @@
         <value xml:lang="nl">Bereken winkelwagen</value>
         <value xml:lang="pt-BR">Recalcular carrinho</value>
         <value xml:lang="pt-PT">Recalcular o Cesto</value>
-        <value xml:lang="ro">Recalculeaza Cos</value>
+        <value xml:lang="ro">Recalculează Coș</value>
         <value xml:lang="ru">Пересчитать корзину</value>
         <value xml:lang="th">คำนวณในตะกร้า</value>
         <value xml:lang="vi">Tính toán lại giỏ hàng</value>
@@ -3004,7 +3065,7 @@
         <value xml:lang="ja">繰り返し</value>
         <value xml:lang="nl">Herhaling</value>
         <value xml:lang="pt-BR">Repetição</value>
-        <value xml:lang="ro">Recurenta</value>
+        <value xml:lang="ro">Recurență</value>
         <value xml:lang="ru">Повторение</value>
         <value xml:lang="th">ย้อนกลับ</value>
         <value xml:lang="vi">Chọn lại tiền tệ</value>
@@ -3019,6 +3080,7 @@
         <value xml:lang="ja">登録</value>
         <value xml:lang="nl">Registreren</value>
         <value xml:lang="pt-BR">Registrar</value>
+        <value xml:lang="ro">Înregistrare</value>
         <value xml:lang="vi">Đăng ký</value>
         <value xml:lang="zh">注册</value>
         <value xml:lang="zh-TW">註冊</value>
@@ -3036,7 +3098,7 @@
         <value xml:lang="nl">Verwijder geselecteerde(n)</value>
         <value xml:lang="pt-BR">Remover selecionados</value>
         <value xml:lang="pt-PT">Remover a Selecção</value>
-        <value xml:lang="ro">Sterge Selectiuni</value>
+        <value xml:lang="ro">Șterge Selecție</value>
         <value xml:lang="ru">Удалить выбранное</value>
         <value xml:lang="th">ลบที่เลือกไว้</value>
         <value xml:lang="vi">Bỏ các mục đã chọn</value>
@@ -3056,7 +3118,7 @@
         <value xml:lang="nl">Vervang door variant</value>
         <value xml:lang="pt-BR">Substituir com variantes</value>
         <value xml:lang="pt-PT">Substituir Com A Alternativa</value>
-        <value xml:lang="ro">Rescrie cu Variante</value>
+        <value xml:lang="ro">Înlocuiește cu varianta</value>
         <value xml:lang="ru">Заменить вариантами</value>
         <value xml:lang="th">แทนที่ด้วยสิ่งที่เปลี่ยนแปลง</value>
         <value xml:lang="vi">Thay đổi với Sản phẩm 'tự tùy chỉnh'</value>
@@ -3091,7 +3153,7 @@
         <value xml:lang="ja">回答</value>
         <value xml:lang="nl">Antwoord</value>
         <value xml:lang="pt-BR">Responder</value>
-        <value xml:lang="ro">Raspuns</value>
+        <value xml:lang="ro">Răspuns</value>
         <value xml:lang="ru">Ответ</value>
         <value xml:lang="th">ตอบรับ</value>
         <value xml:lang="vi">Trả lời</value>
@@ -3109,7 +3171,7 @@
         <value xml:lang="ja">回答:</value>
         <value xml:lang="nl">Antwoorden:</value>
         <value xml:lang="pt-BR">Respostas</value>
-        <value xml:lang="ro">Raspunsuri:</value>
+        <value xml:lang="ro">Răspunsuri:</value>
         <value xml:lang="ru">Ответы:</value>
         <value xml:lang="th">ตอบรับ</value>
         <value xml:lang="vi">Phản hồi</value>
@@ -3127,7 +3189,7 @@
         <value xml:lang="ja">返品リクエスト</value>
         <value xml:lang="nl">Uw terugaveverzoek voor de volgende items:</value>
         <value xml:lang="pt-BR">Pedido de devolução</value>
-        <value xml:lang="ro">Cererea ta de returnare pentru urmatoarele linii:</value>
+        <value xml:lang="ro">Cererea ta de returnare pentru următoarele articole:</value>
         <value xml:lang="ru">Ваш возвращенный запрос на следующие позиции:</value>
         <value xml:lang="th">แสดงคำร้อง</value>
         <value xml:lang="vi">Yêu cầu hoàn trả</value>
@@ -3145,7 +3207,7 @@
         <value xml:lang="ja">返品リクエストを受付ました</value>
         <value xml:lang="nl">Is geaccepteerd. Het teruggavenummer is </value>
         <value xml:lang="pt-BR">Pedido de devolução aceito</value>
-        <value xml:lang="ro">A fos acceptata. Numarul autorizatiei de returnare este #</value>
+        <value xml:lang="ro">Cererea de returnare a fost aprobată. Numărul cererii de returnare este #</value>
         <value xml:lang="ru">был принят. Ваш номер авторизации возврата №</value>
         <value xml:lang="th">แสดงคำร้องที่เป็นที่ยอมรับ</value>
         <value xml:lang="vi">Yêu cầu hoàn trả được chấp nhận</value>
@@ -3163,7 +3225,7 @@
         <value xml:lang="ja">返品リクエストを取り消しました</value>
         <value xml:lang="nl">is geannuleerd.</value>
         <value xml:lang="pt-BR">Pedido de devolução cancelado</value>
-        <value xml:lang="ro">a fost sters.</value>
+        <value xml:lang="ro">a fost anulată.</value>
         <value xml:lang="ru">был отменен.</value>
         <value xml:lang="th">แสดงคำร้องที่ถูกยกเลิก</value>
         <value xml:lang="vi">Yêu cầu hoàn trả được hủy bỏ</value>
@@ -3181,7 +3243,7 @@
         <value xml:lang="ja">返品リクエストが完了しました</value>
         <value xml:lang="nl">is ontvangen en gereed.</value>
         <value xml:lang="pt-BR">Pedido de devolução compĺetado</value>
-        <value xml:lang="ro">a fost primita si completata.</value>
+        <value xml:lang="ro">a fost finalizată.</value>
         <value xml:lang="ru">был принят и выполнен.</value>
         <value xml:lang="th">แสดงคำร้องที่เสร็จสมบูรณ์แล้ว</value>
         <value xml:lang="vi">Yêu cầu hoàn trả hoàn thành</value>
@@ -3199,7 +3261,7 @@
         <value xml:lang="ja">返品リクエストNo</value>
         <value xml:lang="nl">Uw terugaveverzoeknummer</value>
         <value xml:lang="pt-BR">Número do pedido de devolução</value>
-        <value xml:lang="ro">Cererea ta #</value>
+        <value xml:lang="ro">Cererea ta de retur #</value>
         <value xml:lang="ru">Ваш запрос возврата №</value>
         <value xml:lang="th">แสดงจำนวนคำร้อง</value>
         <value xml:lang="vi">Số yêu cầu hoàn trả</value>
@@ -3217,7 +3279,7 @@
         <value xml:lang="ja">検索番号</value>
         <value xml:lang="nl">Zoek nummer</value>
         <value xml:lang="pt-BR">Buscar por número</value>
-        <value xml:lang="ro">Cauta #</value>
+        <value xml:lang="ro">Caută #</value>
         <value xml:lang="ru">Искать №</value>
         <value xml:lang="th">ค้นหา #</value>
         <value xml:lang="vi">Số tìm kiếm</value>
@@ -3233,6 +3295,7 @@
         <value xml:lang="ja">店舗ポリシーを参照</value>
         <value xml:lang="nl">Algemene voorwaarden</value>
         <value xml:lang="pt-BR">Confira a política da loja aqui</value>
+        <value xml:lang="ro">Vezi aici politicile magazinului</value>
         <value xml:lang="th">ดูหลักการเก็บข้อมูลที่นี่</value>
         <value xml:lang="vi">Xem Quy định gian hàng tại đây</value>
         <value xml:lang="zh">看这里的店铺政策</value>
@@ -3248,7 +3311,7 @@
         <value xml:lang="ja">選択頻度</value>
         <value xml:lang="nl">Selecteer frequentie</value>
         <value xml:lang="pt-BR">Selecione a frequência</value>
-        <value xml:lang="ro">Selectioneaza Frecventa</value>
+        <value xml:lang="ro">Selectați Frecvența</value>
         <value xml:lang="ru">Выбрать частоту</value>
         <value xml:lang="th">เลือกความถี่</value>
         <value xml:lang="vi">Lựa chọn tần suất lặp lại</value>
@@ -3266,7 +3329,7 @@
         <value xml:lang="ja">選択したギフト包装</value>
         <value xml:lang="nl">De geselecteerde geschenkverpakking is niet beschikbaar voor alle items. De items die beschikbaar zijn, zijn geselecteerd, de anderen zijn niet veranderd.</value>
         <value xml:lang="pt-BR">Selecione o pacote para presente</value>
-        <value xml:lang="ro">Selectioneaza Omagiu indisponibil pentru toate liniile. Liniile care sunt disponibile vor fi selectionate, celelalte vor ramane invariate.</value>
+        <value xml:lang="ro">Ambalaj cadou selectat</value>
         <value xml:lang="ru">Выбранная подарочная упаковка не доступна для всех позиций. Выбраны только позиции для которых упаковка доступна.</value>
         <value xml:lang="th">เลือกห่อของขวัญ</value>
         <value xml:lang="vi">Đã chọn kiểu gói quà</value>
@@ -3284,7 +3347,7 @@
         <value xml:lang="ja">選択間隔</value>
         <value xml:lang="nl">Selecteer interval</value>
         <value xml:lang="pt-BR">Selecione o intervalo</value>
-        <value xml:lang="ro">Selectioneaza Intervalul</value>
+        <value xml:lang="ro">Selectați Intervalul</value>
         <value xml:lang="ru">Выбрать интервал</value>
         <value xml:lang="th">เลือกช่วงเวลา</value>
         <value xml:lang="vi">Lựa chọn khoảng lặp lại</value>
@@ -3297,6 +3360,7 @@
         <value xml:lang="fr">Sélectionnez une option</value>
         <value xml:lang="ja">オプションを選択</value>
         <value xml:lang="nl">Selecteer opties</value>
+        <value xml:lang="ro">Selectați Opțiune</value>
         <value xml:lang="zh">选择选项</value>
         <value xml:lang="zh-TW">選擇選項</value>
     </property>
@@ -3329,7 +3393,7 @@
         <value xml:lang="ja">通常に設定</value>
         <value xml:lang="nl">Zet op de standaardwaarde</value>
         <value xml:lang="pt-BR">Escolher como padrão</value>
-        <value xml:lang="ro">Setare de Default</value>
+        <value xml:lang="ro">Setare ca implicit</value>
         <value xml:lang="ru">Установить по умолчанию</value>
         <value xml:lang="th">กำหนดค่าที่เลือก</value>
         <value xml:lang="vi">Đặt mặc định</value>
@@ -3345,6 +3409,7 @@
         <value xml:lang="ja">発送アイテム</value>
         <value xml:lang="nl">Verzenditems</value>
         <value xml:lang="pt-BR">Itens do envio</value>
+        <value xml:lang="ro">Articole expediate</value>
         <value xml:lang="th">รายการการขนส่ง</value>
         <value xml:lang="vi">Hàng hóa được chuyển</value>
         <value xml:lang="zh">货运明细</value>
@@ -3363,7 +3428,7 @@
         <value xml:lang="nl">Boodschappenlijst detail</value>
         <value xml:lang="pt-BR">Detalhes da lista de compras</value>
         <value xml:lang="pt-PT">Detalhe da Lista de Compras</value>
-        <value xml:lang="ro">Detalii Lista de Cumparare </value>
+        <value xml:lang="ro">Detalii Listă de Cumpărături</value>
         <value xml:lang="ru">Подробности списка покупок</value>
         <value xml:lang="th">รายละเอียดรายการซื้อสินค้า</value>
         <value xml:lang="vi">Chi tiết danh sách mua sắm</value>
@@ -3383,7 +3448,7 @@
         <value xml:lang="nl">Boodschappenlijst is leeg</value>
         <value xml:lang="pt-BR">Lista de compras vazia</value>
         <value xml:lang="pt-PT">A Sua Lista De Compras Está Vazia</value>
-        <value xml:lang="ro">Lista ta de cumparare este goala</value>
+        <value xml:lang="ro">Lista ta de cumpărături este goală</value>
         <value xml:lang="ru">Вас список покупок пуст</value>
         <value xml:lang="th">ไม่มีรายการซื้อสินค้า</value>
         <value xml:lang="vi">Danh sách mua sắm trống</value>
@@ -3403,7 +3468,7 @@
         <value xml:lang="nl">Fout: De gespecificeerde boodschappenlijst (met</value>
         <value xml:lang="pt-BR">Erro na lista de compras</value>
         <value xml:lang="pt-PT">ERRO:A lista de compras especificada</value>
-        <value xml:lang="ro">EROARE:Lista de cumparare specificata (cu</value>
+        <value xml:lang="ro">EROARE: Lista de cumpărături specificată (cu</value>
         <value xml:lang="ru">ОШИБКА: Указанный список покупок (с</value>
         <value xml:lang="th">ERROR: ผิดพลาด !เกิดความผิดพลาดในรายการซื้อสินค้า</value>
         <value xml:lang="vi">Danh sách mua sắm lỗi</value>
@@ -3423,7 +3488,7 @@
         <value xml:lang="nl">Boodschappenlijst prijs totalen</value>
         <value xml:lang="pt-BR">Preço total da lista de compras</value>
         <value xml:lang="pt-PT">Preços Totais Da Lista De Compras</value>
-        <value xml:lang="ro">Pret Total Liste de Cumparare</value>
+        <value xml:lang="ro">Preț Total Liste de Cumpărături</value>
         <value xml:lang="ru">Итоговая стоимость списка покупок</value>
         <value xml:lang="th">รายการราคาสินค้าทั้งหมด</value>
         <value xml:lang="vi">Tổng giá Danh sách mua sắm</value>
@@ -3442,7 +3507,7 @@
         <value xml:lang="ja">買い物リスト再注文</value>
         <value xml:lang="nl">Boodschappenlijst opnieuw bestellen informatie</value>
         <value xml:lang="pt-BR">Reordenar lista de compras</value>
-        <value xml:lang="ro">Info Re-Comanda Lista Cumparare</value>
+        <value xml:lang="ro">Reordonați lista de cumpărături</value>
         <value xml:lang="ru">Информация для повторного заказа по списку покупок</value>
         <value xml:lang="th">รายการสั่งซื้อสินค้าใหม่</value>
         <value xml:lang="vi">Đặt hàng lại Danh sách mua sắm</value>
@@ -3462,7 +3527,7 @@
         <value xml:lang="nl">Boodschappenlijst</value>
         <value xml:lang="pt-BR">Listas de compras</value>
         <value xml:lang="pt-PT">Listas de Compras</value>
-        <value xml:lang="ro">Liste Cumparare</value>
+        <value xml:lang="ro">Liste Cumpărături</value>
         <value xml:lang="ru">Списки покупок</value>
         <value xml:lang="th">รายการซื้อสินค้า</value>
         <value xml:lang="vi">Danh sách mua sắm</value>
@@ -3477,6 +3542,7 @@
         <value xml:lang="ja">簡単な名称</value>
         <value xml:lang="nl">Korte naam</value>
         <value xml:lang="pt-BR">Apelido</value>
+        <value xml:lang="ro">Nume scurt</value>
         <value xml:lang="vi">Tên tắt</value>
         <value xml:lang="zh">简称</value>
         <value xml:lang="zh-TW">簡稱</value>
@@ -3508,6 +3574,7 @@
         <value xml:lang="ja">連絡リストに会員登録</value>
         <value xml:lang="nl">Aanmelden voor nieuwsbrief</value>
         <value xml:lang="pt-BR">Registre-se na lista de contato</value>
+        <value xml:lang="ro">Înscrieți-vă in lista de contacte</value>
         <value xml:lang="th">ข่าวสาร</value>
         <value xml:lang="vi">Đăng ký nhận Tin</value>
         <value xml:lang="zh">注册用于联系列表</value>
@@ -3522,6 +3589,7 @@
         <value xml:lang="ja">連絡リスト会員登録のコメント</value>
         <value xml:lang="nl">Registreren om aan te melden voor nieuwsbrief commentaren</value>
         <value xml:lang="pt-BR">Registre-se para comentar a lista de contatos</value>
+        <value xml:lang="ro">Înscrieți-vă pentru comentarii la lista de contacte</value>
         <value xml:lang="th">ถ้าคุณสนใจในข่าวสารให้คุณกรอกที่อยู่อีเมลข้างล่างนี้และลงทะเบียน :</value>
         <value xml:lang="vi">Đăng ký vào danh sách Thảo luận</value>
         <value xml:lang="zh">注册用于联系列表评论</value>
@@ -3536,6 +3604,7 @@
         <value xml:lang="ja">連絡リスト会員登録のログイン</value>
         <value xml:lang="nl">Registreren om aan te melden voor nieuwsbrief</value>
         <value xml:lang="pt-BR">Registre-se para entrar na lista de contatos</value>
+        <value xml:lang="ro">Înscrieți-vă in lista de contacte Autentificare</value>
         <value xml:lang="th">ถ้าคุณสนใจข่าวสารกรุณาลอกอินเข้าสู่ระบบและลงทะเบียน:</value>
         <value xml:lang="vi">Đăng nhập</value>
         <value xml:lang="zh">注册用于联系列表登录</value>
@@ -3552,7 +3621,7 @@
         <value xml:lang="ja">シルバー</value>
         <value xml:lang="nl">Zilver</value>
         <value xml:lang="pt-BR">Prata</value>
-        <value xml:lang="ro">Argent</value>
+        <value xml:lang="ro">Argint</value>
         <value xml:lang="ru">Серебряный</value>
         <value xml:lang="th">สีเงิน</value>
         <value xml:lang="vi">Bạc</value>
@@ -3567,6 +3636,7 @@
         <value xml:lang="ja">申し訳ございません、ソフトウェア製品のアップロードは許可されていません。</value>
         <value xml:lang="nl">Excusus, het uploaden van digitale producten is gedeactiveerd.</value>
         <value xml:lang="pt-BR">Desculpe, o upload de produtos digitais não está ativado.</value>
+        <value xml:lang="ro">Ne pare rău, încărcarea produselor digitale nu este activată.</value>
         <value xml:lang="vi">Rất tiếc, Quản trị không cho phép Tải lên sản phẩm .</value>
         <value xml:lang="zh">对不起，不允许上传数字产品。</value>
         <value xml:lang="zh-TW">抱歉, 不允許上傳數位產品.</value>
@@ -3582,7 +3652,7 @@
         <value xml:lang="ja">開始</value>
         <value xml:lang="nl">Begindatum</value>
         <value xml:lang="pt-BR">Início</value>
-        <value xml:lang="ro">Data Initiala</value>
+        <value xml:lang="ro">Data Inițială</value>
         <value xml:lang="ru">Дата начала</value>
         <value xml:lang="th">วันที่เริ่มต้น</value>
         <value xml:lang="vi">Bắt đầu</value>
@@ -3600,7 +3670,7 @@
         <value xml:lang="ja">開始日</value>
         <value xml:lang="nl">Begindatum</value>
         <value xml:lang="pt-BR">Data de início</value>
-        <value xml:lang="ro">Data Initiala</value>
+        <value xml:lang="ro">Data inițială</value>
         <value xml:lang="ru">Датаначала</value>
         <value xml:lang="th">วันที่เริ่มต้น</value>
         <value xml:lang="vi">Ngày bắt đầu</value>
@@ -3616,6 +3686,7 @@
         <value xml:lang="ja">ステップ</value>
         <value xml:lang="nl">Stap</value>
         <value xml:lang="pt-BR">Passo</value>
+        <value xml:lang="ro">Pas</value>
         <value xml:lang="vi">Bước</value>
         <value xml:lang="zh">步骤</value>
         <value xml:lang="zh-TW">步驟</value>
@@ -3631,7 +3702,7 @@
         <value xml:lang="ja">件名</value>
         <value xml:lang="nl">Onderwerp</value>
         <value xml:lang="pt-BR">Assunto</value>
-        <value xml:lang="ro">Subiect </value>
+        <value xml:lang="ro">Subiect</value>
         <value xml:lang="ru">Тема</value>
         <value xml:lang="th">หัวข้อ</value>
         <value xml:lang="vi">Chủ đề</value>
@@ -3642,6 +3713,7 @@
         <value xml:lang="en">Subject is missing</value>
         <value xml:lang="ja">件名が正しくありません</value>
         <value xml:lang="nl">Onderwerp ontbreekt</value>
+        <value xml:lang="ro">Subiectul lipsește</value>
         <value xml:lang="vi">Chủ đề chưa có</value>
         <value xml:lang="zh">缺少主题</value>
         <value xml:lang="zh-TW">缺少主題</value>
@@ -3656,7 +3728,7 @@
         <value xml:lang="ja">申込</value>
         <value xml:lang="nl">Abonneren</value>
         <value xml:lang="pt-BR">Inscrever-se</value>
-        <value xml:lang="ro">Subscrie </value>
+        <value xml:lang="ro">Abonare</value>
         <value xml:lang="ru">Подписаться</value>
         <value xml:lang="th">ชำระค่าสั่งซื้อ</value>
         <value xml:lang="vi">Ghi danh Nhận</value>
@@ -3671,6 +3743,7 @@
         <value xml:lang="ja">確認メールの申込</value>
         <value xml:lang="nl">Verificatie aanmelden abonnement</value>
         <value xml:lang="pt-BR">E-mail de verificação de inscrição</value>
+        <value xml:lang="ro">E-mail de verificare a abonarii</value>
         <value xml:lang="vi">Thư điện tử xác nhận Ghi danh</value>
         <value xml:lang="zh">订阅验证电子邮件</value>
         <value xml:lang="zh-TW">訂閱驗證電子郵件</value>
@@ -3686,7 +3759,7 @@
         <value xml:lang="ja">サマリ情報</value>
         <value xml:lang="nl">Beknopte informatie</value>
         <value xml:lang="pt-BR">Dados do resumo</value>
-        <value xml:lang="ro">Informatii Breviar</value>
+        <value xml:lang="ro">Sumar Informații</value>
         <value xml:lang="ru">Итоговая информация</value>
         <value xml:lang="th">สรุปข้อมูล</value>
         <value xml:lang="vi">Thông tin tổng hợp </value>
@@ -3717,6 +3790,7 @@
         <value xml:lang="fr">Nuage de mots</value>
         <value xml:lang="ja">クラウドにタグ</value>
         <value xml:lang="nl">Tags</value>
+        <value xml:lang="ro">Etichete</value>
         <value xml:lang="vi">Đám mây đánh dấu</value>
         <value xml:lang="zh">标签云</value>
         <value xml:lang="zh-TW">標籤雲</value>
@@ -3732,7 +3806,7 @@
         <value xml:lang="ja">評価する</value>
         <value xml:lang="nl">Vul enquete in</value>
         <value xml:lang="pt-BR">Responda a enquete</value>
-        <value xml:lang="ro">Raspunde Sondaj</value>
+        <value xml:lang="ro">Răspunde la Sondaj</value>
         <value xml:lang="ru">Сделать обзор</value>
         <value xml:lang="th">ทำการสำรวจ</value>
         <value xml:lang="vi">Tiến hành khảo sát</value>
@@ -3750,7 +3824,7 @@
         <value xml:lang="ja">友達に教える</value>
         <value xml:lang="nl">Vertel het aan een kennis</value>
         <value xml:lang="pt-BR">Envie para um amigo</value>
-        <value xml:lang="ro">Spunei unui Amic</value>
+        <value xml:lang="ro">Spune-i unui Amic</value>
         <value xml:lang="ru">Расказать другу</value>
         <value xml:lang="th">แนะนำเพื่อน</value>
         <value xml:lang="vi">Giới thiệu với Bạn</value>
@@ -3768,7 +3842,7 @@
         <value xml:lang="ja">申し訳ございません。このページを友達に教えることはできません。カテゴリか製品を選択してください。</value>
         <value xml:lang="nl">Sorry, maar u kan deze pagina niet naar een kennis sturen. Selecteer een categorie of een product.</value>
         <value xml:lang="pt-BR">Desculpe-nos, impossível enviar este e-mail. Selecione outro produto ou categoria.</value>
-        <value xml:lang="ro">Ne pare rau, nu este posibila trimiterea acestei pagini la un amic. Va rugam selectionti de la o alta categorie sau produs.</value>
+        <value xml:lang="ro">Ne pare rău, nu este posibilă trimiterea acestei pagini unui amic. Vă rugăm selectați o altă categorie sau produs.</value>
         <value xml:lang="ru">Извините, вы не можете переслать эту страницу другу. Пожалуйста выберите или категорию или продукт.</value>
         <value xml:lang="th">แสดงความเสียใจกับเพื่อน</value>
         <value xml:lang="vi">Xin lỗi tới Bạn bè</value>
@@ -3804,7 +3878,7 @@
         <value xml:lang="ja">登録ありがとうございます</value>
         <value xml:lang="nl">Onze dank voor het registeren bij</value>
         <value xml:lang="pt-BR">Obrigado por registrar-se</value>
-        <value xml:lang="ro">Multumesc, pentru ca te-ai inregistrat cu </value>
+        <value xml:lang="ro">Multumim pentru că te-ai înregistrat cu </value>
         <value xml:lang="ru">Спасибо что зарегистрировались с</value>
         <value xml:lang="th">ขอบคุณสำหรับการลงทะเบียน</value>
         <value xml:lang="vi">Cảm ơn đã đăng ký</value>
@@ -3860,7 +3934,7 @@
         <value xml:lang="nl">Totale Prijs</value>
         <value xml:lang="pt-BR">Preço total</value>
         <value xml:lang="pt-PT">Preço Total</value>
-        <value xml:lang="ro">Pret Total</value>
+        <value xml:lang="ro">Preț Total</value>
         <value xml:lang="ru">Итоговая цена</value>
         <value xml:lang="th">ราคารวม</value>
         <value xml:lang="vi">Tổng giá</value>
@@ -3880,7 +3954,7 @@
         <value xml:lang="nl">Prijs per stuk</value>
         <value xml:lang="pt-BR">Preço unitário</value>
         <value xml:lang="pt-PT">Preço Unitário</value>
-        <value xml:lang="ro">Pret Unitar</value>
+        <value xml:lang="ro">Preț Unitar</value>
         <value xml:lang="ru">Стоимость единицы</value>
         <value xml:lang="th">ราคาต่อหน่วย</value>
         <value xml:lang="vi">Giá (đơn chiếc)</value>
@@ -3897,7 +3971,7 @@
         <value xml:lang="ja">登録解除</value>
         <value xml:lang="nl">Beëindigen abonnement</value>
         <value xml:lang="pt-BR">Encerrar seu registro</value>
-        <value xml:lang="ro">Sterge Subscrierea</value>
+        <value xml:lang="ro">Dezabonare</value>
         <value xml:lang="ru">Отменить подписку</value>
         <value xml:lang="th">ไม่ได้ชำระค่าสั่งซื้อ</value>
         <value xml:lang="vi">Hủy ghi danh Nhận</value>
@@ -3915,7 +3989,7 @@
         <value xml:lang="ja">サポートしていない質問種類</value>
         <value xml:lang="nl">Niet ondersteunde vraag soort</value>
         <value xml:lang="pt-BR">Tipo de pergunta não suportada</value>
-        <value xml:lang="ro">Tip de intrebare nesuportata</value>
+        <value xml:lang="ro">Tip de întrebare neacceptat</value>
         <value xml:lang="ru">Не поддерживаемй тип вопроса</value>
         <value xml:lang="th">ไม่สอดคล้องกับประเภทคำถาม</value>
         <value xml:lang="vi">Loại câu hỏi không hỗ trợ</value>
@@ -3932,7 +4006,7 @@
         <value xml:lang="ja">ソフトウェア製品を更新</value>
         <value xml:lang="nl">Wijzig digitaal product</value>
         <value xml:lang="pt-BR">Atualizar produto digital</value>
-        <value xml:lang="ro">Adauga Produs Digital</value>
+        <value xml:lang="ro">Actualizare Produs Digital</value>
         <value xml:lang="ru">Обновить цифровые продукты</value>
         <value xml:lang="th">เปลี่ยนแปลงสินค้าดิจิตัล</value>
         <value xml:lang="vi">Cập nhật sản phẩm</value>
@@ -3967,7 +4041,7 @@
         <value xml:lang="ja">新規ファイルをアップロード</value>
         <value xml:lang="nl">Upload nieuw bestand</value>
         <value xml:lang="pt-BR">Fazer upload de um novo arquivo</value>
-        <value xml:lang="ro">Incarca un Nou Fisier</value>
+        <value xml:lang="ro">Incarcă un Fișier nou</value>
         <value xml:lang="ru">Загрузить новый файл</value>
         <value xml:lang="th">โหลดไฟล์ใหม่</value>
         <value xml:lang="vi">Tải lên một tập tin mới</value>
@@ -3985,7 +4059,7 @@
         <value xml:lang="ja">Eメールアドレスを使用</value>
         <value xml:lang="nl">Gebruik emailadres</value>
         <value xml:lang="pt-BR">Use o endereço de e-mail</value>
-        <value xml:lang="ro">Foloseste Adresa Email</value>
+        <value xml:lang="ro">Folosește Adresa de Email</value>
         <value xml:lang="ru">Использовать Email</value>
         <value xml:lang="th">ใช้ที่อยู่อีเมล์</value>
         <value xml:lang="vi">Sử dụng địa chỉ thư điện tử</value>
@@ -4041,7 +4115,7 @@
         <value xml:lang="ja">すべて表示</value>
         <value xml:lang="nl">Alles bekijken</value>
         <value xml:lang="pt-BR">Ver todos</value>
-        <value xml:lang="ro">Visualizza Tot</value>
+        <value xml:lang="ro">Vezi Tot</value>
         <value xml:lang="ru">Промотреть все</value>
         <value xml:lang="th">ดูทั้งหมด</value>
         <value xml:lang="vi">Xem toàn bộ</value>
@@ -4059,7 +4133,7 @@
         <value xml:lang="ja">一覧を表示</value>
         <value xml:lang="nl">Kijk in de lijst</value>
         <value xml:lang="pt-BR">Visualizar lista</value>
-        <value xml:lang="ro">Vizualizeaza Lista</value>
+        <value xml:lang="ro">Vezi Lista</value>
         <value xml:lang="ru">Просмотреть список</value>
         <value xml:lang="th">ดูรายการ</value>
         <value xml:lang="vi">Xem danh sách</value>
@@ -4077,7 +4151,7 @@
         <value xml:lang="ja">受信のみ表示</value>
         <value xml:lang="nl">Bekijken ontvangen berichten</value>
         <value xml:lang="pt-BR">Visualizar apenas mensagens recebidas</value>
-        <value xml:lang="ro">Vizualizeaza Mesaje Primite </value>
+        <value xml:lang="ro">Vezi Mesaje Primite</value>
         <value xml:lang="ru">Просмотреть принятые сообщения</value>
         <value xml:lang="th">ดูที่ได้รับเพียงอย่างเดียว</value>
         <value xml:lang="vi">Hiển thị các thông điệp đã Nhận</value>
@@ -4095,7 +4169,7 @@
         <value xml:lang="ja">送信を表示</value>
         <value xml:lang="nl">Bekijk verzonden en ontvangen</value>
         <value xml:lang="pt-BR">Visualizar apenas mensagens enviadas</value>
-        <value xml:lang="ro">Vizualizeaza Trimite si Primeste</value>
+        <value xml:lang="ro">Vezi Trimise</value>
         <value xml:lang="ru">Просмотреть отосланные и принятые</value>
         <value xml:lang="th">ดูที่ส่ง</value>
         <value xml:lang="vi">Hiển thị các thông điệp đã Gửi</value>
@@ -4107,6 +4181,7 @@
         <value xml:lang="it">Anni all'indirizzo non è un numero valido: ${parameters.yearsAtAddress}</value>
         <value xml:lang="ja">住所が有効でない年数: ${parameters.yearsAtAddress}</value>
         <value xml:lang="nl">Jaren op adres niet correct: ${parameters.yearsAtAddress}</value>
+        <value xml:lang="ro">Ani la adresa nu este un număr valid: ${parameters.yearsAtAddress}</value>
         <value xml:lang="vi">Số năm không phải là số hợp lệ tại địa chỉ: ${parameters.yearsAtAddress}</value>
         <value xml:lang="zh">在地址的年数不是一个有效数字：${parameters.yearsAtAddress}</value>
         <value xml:lang="zh-TW">在位址的年數不是一個有效數字:${parameters.yearsAtAddress}</value>
@@ -4116,6 +4191,7 @@
         <value xml:lang="it">Anni come impiegato non è un numero valido: ${parameters.yearsWithEmployer}</value>
         <value xml:lang="ja">雇用者が有効でない年数: ${parameters.yearsWithEmployer}</value>
         <value xml:lang="nl">Jaren bij werkgever niet correct: ${parameters.yearsWithEmployer}</value>
+        <value xml:lang="ro">Ani cu Angajatorul nu a fost un număr valid: ${parameters.yearsWithEmployer}</value>
         <value xml:lang="vi">Số năm không phải là số hợp lệ với Nhân viên: ${parameters.yearsWithEmployer}</value>
         <value xml:lang="zh">雇主的年数不是一个有效数字：${parameters.yearsWithEmployer}</value>
         <value xml:lang="zh-TW">雇主的年數不是一個有效數字:${parameters.yearsWithEmployer}</value>
@@ -4149,7 +4225,7 @@
         <value xml:lang="ja">送信済</value>
         <value xml:lang="nl">Verzonden naar u; </value>
         <value xml:lang="pt-BR">Você recebeu um</value>
-        <value xml:lang="ro">Tu ai trimis un</value>
+        <value xml:lang="ro">Ți-a fost trimis un</value>
         <value xml:lang="ru">Вы отослали</value>
         <value xml:lang="th">คุณมีการส่ง</value>
         <value xml:lang="vi">Bạn đã gửi</value>
@@ -4169,7 +4245,7 @@
         <value xml:lang="nl">Misschien bent u ook geinteresserd in</value>
         <value xml:lang="pt-BR">Talvez isto lhe interesse também:</value>
         <value xml:lang="pt-PT">Também estará interessado neste(s)</value>
-        <value xml:lang="ro">Ai putea sa fii interesat si de </value>
+        <value xml:lang="ro">Ai putea să fii interesat și de</value>
         <value xml:lang="ru">Вас может также заинтересовать</value>
         <value xml:lang="th">สิ่งที่คุณสนใจ</value>
         <value xml:lang="vi">Có thể cũng Bạn cũng thích thú với</value>
@@ -4189,7 +4265,7 @@
         <value xml:lang="nl">U wilt misschien graag</value>
         <value xml:lang="pt-BR">Você talvez goste:</value>
         <value xml:lang="pt-PT">Também vai gostar</value>
-        <value xml:lang="ro">Ti-ar place </value>
+        <value xml:lang="ro">S-ar putea să vă placă</value>
         <value xml:lang="ru">Вам может понравиться</value>
         <value xml:lang="th">สิ่งที่น่าสนใจ</value>
         <value xml:lang="vi">Bạn có thể cũng thích</value>
@@ -4205,6 +4281,7 @@
         <value xml:lang="ja">あなたの</value>
         <value xml:lang="nl">uw</value>
         <value xml:lang="pt-BR">seu</value>
+        <value xml:lang="ro">dvs</value>
         <value xml:lang="th">ของคุณ</value>
         <value xml:lang="vi">của bạn</value>
         <value xml:lang="zh">你的</value>
@@ -4221,7 +4298,7 @@
         <value xml:lang="ja">カード番号</value>
         <value xml:lang="nl">Uw kaartnummer:</value>
         <value xml:lang="pt-BR">O número de seu cartão:</value>
-        <value xml:lang="ro">Numarul Cartii tale:</value>
+        <value xml:lang="ro">Numărul cardului:</value>
         <value xml:lang="ru">Номер вашей карты:</value>
         <value xml:lang="th">หมายเลขบัตรของคุณ</value>
         <value xml:lang="vi">Số thẻ của bạn</value>
@@ -4239,7 +4316,7 @@
         <value xml:lang="ja">ギフトカード</value>
         <value xml:lang="nl">Uw geschenkkaart :</value>
         <value xml:lang="pt-BR">Seu cartão de presente</value>
-        <value xml:lang="ro">Cartea ta de omagiu :</value>
+        <value xml:lang="ro">Cardul dvs. cadou</value>
         <value xml:lang="ru">Ваша дисконтная карта :</value>
         <value xml:lang="th">บัตรของขวัญของคุณ</value>
         <value xml:lang="vi">Thẻ tặng quà của bạn</value>
@@ -4254,6 +4331,7 @@
         <value xml:lang="ja">ギフトカードチャージ後</value>
         <value xml:lang="nl">Uw geschenkkaart heeft</value>
         <value xml:lang="pt-BR">Seu cartão de presente recarregado tem</value>
+        <value xml:lang="ro">Cardul dvs. cadou a fost reîncărcat</value>
         <value xml:lang="vi">Thẻ tặng quà đã tải lại của bạn có</value>
         <value xml:lang="zh">你充值的礼品卡有</value>
         <value xml:lang="zh-TW">你儲值禮物卡有</value>
@@ -4263,6 +4341,7 @@
         <value xml:lang="en">Your order is being processed, this may take a moment...</value>
         <value xml:lang="ja">注文は処理中です。しばらくお待ちください...</value>
         <value xml:lang="nl">Uw opdracht wordt verwerkt</value>
+        <value xml:lang="ro">Comanda dvs. este în curs de procesare, aceasta poate dura un moment...</value>
         <value xml:lang="vi">Yêu cầu của bạn đang được xử lý, có thể mất một vài phút...</value>
         <value xml:lang="zh">正在处理你的订单，可能需要一会儿...</value>
         <value xml:lang="zh-TW">正在處理你的訂單,可能需要一會兒...</value>
@@ -4272,6 +4351,7 @@
         <value xml:lang="en">Your Name, Phone Number and E-Mail</value>
         <value xml:lang="ja">あなたの名前、電話番号、および電子メール</value>
         <value xml:lang="nl">Uw gegevens</value>
+        <value xml:lang="ro">Numele, numărul de telefon și e-mailul dvs</value>
         <value xml:lang="vi">Tên, số điện thoại và thư điện tử của bạn</value>
         <value xml:lang="zh">你的名字、电话号码和电子邮件</value>
         <value xml:lang="zh-TW">你的名字、電話號碼和電子郵件</value>
@@ -4287,7 +4367,7 @@
         <value xml:lang="ja">PIN番号</value>
         <value xml:lang="nl">Uw pinnummer :</value>
         <value xml:lang="pt-BR">Seu número de Pin é:</value>
-        <value xml:lang="ro">Numarul tau de Pin :</value>
+        <value xml:lang="ro">Pin-ul:</value>
         <value xml:lang="ru">Ваш ПИК код :</value>
         <value xml:lang="th">หมายเลขรหัสส่วนตัวของคุณ</value>
         <value xml:lang="vi">Mã Pin của bạn</value>
@@ -4308,7 +4388,7 @@
         <value xml:lang="nl">Uw winkelwagen is leeg</value>
         <value xml:lang="pt-BR">Seu carrinho de compras está vazio</value>
         <value xml:lang="pt-PT">O seu Cesto de compras está vazio</value>
-        <value xml:lang="ro">Cosul de cumparaturi este gol </value>
+        <value xml:lang="ro">Coșul de cumpărături este gol</value>
         <value xml:lang="ru">Ваша корзина пустая</value>
         <value xml:lang="th">ไม่มีการซื้อสินค้าลงตะกร้าของคุณ</value>
         <value xml:lang="vi">Giỏ hàng của bạn rỗng</value>
@@ -4326,7 +4406,7 @@
         <value xml:lang="ja">追加の情報</value>
         <value xml:lang="nl">Extra informatie</value>
         <value xml:lang="pt-BR">Dados adicionais</value>
-        <value xml:lang="ro">Informatii Suplimentare</value>
+        <value xml:lang="ro">Informații Suplimentare</value>
         <value xml:lang="ru">Дополнительная информация</value>
         <value xml:lang="th">ข้อมูลเพิ่มเติม</value>
         <value xml:lang="vi">Thông tin miêu tả thêm</value>
@@ -4344,7 +4424,7 @@
         <value xml:lang="ja">回答を追加</value>
         <value xml:lang="nl">Voeg antwoord toe</value>
         <value xml:lang="pt-BR">Adicionar uma resposta</value>
-        <value xml:lang="ro">Adauga Raspuns</value>
+        <value xml:lang="ro">Adaugă Răspuns</value>
         <value xml:lang="ru">Добавить ответ</value>
         <value xml:lang="th">เพิ่มคำตอบ</value>
         <value xml:lang="vi">Thêm phản hồi</value>
@@ -4362,7 +4442,7 @@
         <value xml:lang="ja">請求情報</value>
         <value xml:lang="nl">Factuur informatie</value>
         <value xml:lang="pt-BR">Dados de cobrança</value>
-        <value xml:lang="ro">Informatii Facturare</value>
+        <value xml:lang="ro">Informații Facturare</value>
         <value xml:lang="ru">Информация об оплате</value>
         <value xml:lang="th">ข้อมูลใบเสร็จรับเงิน</value>
         <value xml:lang="vi">Thông tin thanh toán</value>
@@ -4382,7 +4462,7 @@
         <value xml:lang="nl">Wijzig wachtwoord</value>
         <value xml:lang="pt-BR">Alterar senha</value>
         <value xml:lang="pt-PT">Alterar Senha</value>
-        <value xml:lang="ro">Schimbare Password</value>
+        <value xml:lang="ro">Schimbare parolă</value>
         <value xml:lang="ru">Изменить пароль</value>
         <value xml:lang="th">เปลี่ยนรหัสผ่าน</value>
         <value xml:lang="vi">Đổi mật khẩu</value>
@@ -4401,7 +4481,7 @@
         <value xml:lang="nl">Besteloverzicht</value>
         <value xml:lang="pt-BR">Revisão do pagamento</value>
         <value xml:lang="pt-PT">Revisão de Pagamento</value>
-        <value xml:lang="ro">Revizioneaza Checkout</value>
+        <value xml:lang="ro">Verifică Comandă</value>
         <value xml:lang="ru">Обзор подтверждения</value>
         <value xml:lang="th">ออกจากการตรวจสอบ</value>
         <value xml:lang="vi">Xem lại phần thanh toán</value>
@@ -4508,7 +4588,7 @@
         <value xml:lang="nl">Verander de contactmethode</value>
         <value xml:lang="pt-BR">Editar mecanismo de contato</value>
         <value xml:lang="pt-PT">Editar Mecanismo de Contacto</value>
-        <value xml:lang="ro">Adauga Contact</value>
+        <value xml:lang="ro">Editează Contact</value>
         <value xml:lang="ru">Редактировать контактный механизм</value>
         <value xml:lang="th">แก้ไขข้อมูลการทำงาน</value>
         <value xml:lang="vi">Chỉnh sửa cơ chế (mechanism) liên hệ</value>
@@ -4527,7 +4607,7 @@
         <value xml:lang="nl">Wijzgen bankrekening</value>
         <value xml:lang="pt-BR">Editar conta EFT</value>
         <value xml:lang="pt-PT">Editar Conta EFT</value>
-        <value xml:lang="ro">Actualizeza Cont EFT </value>
+        <value xml:lang="ro">Editează contul de transfer bancar</value>
         <value xml:lang="ru">Изменить текущий счет</value>
         <value xml:lang="th">แก้ไขบัญชีธนาคาร</value>
         <value xml:lang="vi">Chỉnh sửa tài khoản thanh toán điện tử</value>
@@ -4581,7 +4661,7 @@
         <value xml:lang="ja">フォーラム記事</value>
         <value xml:lang="nl">Forum bericht</value>
         <value xml:lang="pt-BR">Artigo do forum</value>
-        <value xml:lang="ro">Forum Articole</value>
+        <value xml:lang="ro">Articole Forum</value>
         <value xml:lang="ru">Статья форума</value>
         <value xml:lang="th">หัวข้อแสดงความคิดเห็น</value>
         <value xml:lang="vi">Bài viết trên diễn đàn</value>
@@ -4598,7 +4678,7 @@
         <value xml:lang="ja">フォーラム回答</value>
         <value xml:lang="nl">Forum antwoord</value>
         <value xml:lang="pt-BR">Resposta do forum</value>
-        <value xml:lang="ro">Forum Raspunsuri </value>
+        <value xml:lang="ro">Raspunsuri Forum</value>
         <value xml:lang="ru">Ответ форума</value>
         <value xml:lang="th">ตอบความคิดเห็น</value>
         <value xml:lang="vi">Phản hồi trong diễn đàn</value>
@@ -4615,7 +4695,7 @@
         <value xml:lang="ja">フォーラムサマリ</value>
         <value xml:lang="nl">Forum overzicht</value>
         <value xml:lang="pt-BR">Resumo do forum</value>
-        <value xml:lang="ro">Forum Rezumat</value>
+        <value xml:lang="ro">Sumar Forum</value>
         <value xml:lang="ru">Итоги форума</value>
         <value xml:lang="th">สรุปความคิดเห็น</value>
         <value xml:lang="vi">Tổng hợp diễn đàn</value>
@@ -4633,7 +4713,7 @@
         <value xml:lang="ja">ギフトカード残高</value>
         <value xml:lang="nl">Geschenkkaart saldo/waarde</value>
         <value xml:lang="pt-BR">Saldo do cartão de presentes</value>
-        <value xml:lang="ro">Bilant Carte Omagiu</value>
+        <value xml:lang="ro">Sold card cadou</value>
         <value xml:lang="ru">Баланс дисконтной карты</value>
         <value xml:lang="th">ยอดคงเหลือในบัตรของขวัญ</value>
         <value xml:lang="vi">Tài khoản thẻ quà tặng</value>
@@ -4651,7 +4731,7 @@
         <value xml:lang="ja">ギフトカードリンク</value>
         <value xml:lang="nl">Geschenkkaart link</value>
         <value xml:lang="pt-BR">Conexão do cartão de presentes</value>
-        <value xml:lang="ro">Link Carte Omagiu</value>
+        <value xml:lang="ro">Link card cadou</value>
         <value xml:lang="ru">Ссылка на дисконтную карту</value>
         <value xml:lang="th">ลิ้งบัตรของขวัญ</value>
         <value xml:lang="vi">Liên kết thẻ quà tặng</value>
@@ -4671,7 +4751,7 @@
         <value xml:lang="nl">Laatst bekeken producten</value>
         <value xml:lang="pt-BR">Últimos produtos visualizados</value>
         <value xml:lang="pt-PT">Últimos Produtos Consultados</value>
-        <value xml:lang="ro">Ultimile Produse Vazute</value>
+        <value xml:lang="ro">Ultimele Produse Văzute</value>
         <value xml:lang="ru">Последний просмотр продуктов</value>
         <value xml:lang="th">ดูสินค้าครั้งสุดท้าย</value>
         <value xml:lang="vi">Các sản phẩm vừa được xem</value>
@@ -4687,6 +4767,7 @@
         <value xml:lang="ja">見積一覧</value>
         <value xml:lang="nl">Lijst offertes</value>
         <value xml:lang="pt-BR">Listar citações</value>
+        <value xml:lang="ro">Lista Oferte</value>
         <value xml:lang="th">อ้างอิงการทำรายการ</value>
         <value xml:lang="vi">Danh sách báo giá</value>
         <value xml:lang="zh">询价列表</value>
@@ -4701,6 +4782,7 @@
         <value xml:lang="ja">リクエスト一覧</value>
         <value xml:lang="nl">Lijst aanvragen</value>
         <value xml:lang="pt-BR">Listar requisições</value>
+        <value xml:lang="ro">Lista cererilor</value>
         <value xml:lang="th">รายการคำร้อง</value>
         <value xml:lang="vi">Danh sách yêu cầu</value>
         <value xml:lang="zh">请求列表</value>
@@ -4735,7 +4817,7 @@
         <value xml:lang="ja">メッセージ一覧</value>
         <value xml:lang="nl">Berichtenlijst</value>
         <value xml:lang="pt-BR">Lista de mensagens</value>
-        <value xml:lang="ro">Lista Mesaj</value>
+        <value xml:lang="ro">Listă Mesaje</value>
         <value xml:lang="ru">Список сообщений</value>
         <value xml:lang="th">รายการข้อความ</value>
         <value xml:lang="vi">Danh sách tin nhắn</value>
@@ -4755,7 +4837,7 @@
         <value xml:lang="nl">Nieuwe klant</value>
         <value xml:lang="pt-BR">Novo cliente</value>
         <value xml:lang="pt-PT">Novo Cliente</value>
-        <value xml:lang="ro">Nou Subiect </value>
+        <value xml:lang="ro">Client nou</value>
         <value xml:lang="ru">Новый пользователь</value>
         <value xml:lang="th">ลูกค้าใหม่</value>
         <value xml:lang="vi">Khách hàng mới</value>
@@ -4773,7 +4855,7 @@
         <value xml:lang="ja">新規メッセージ</value>
         <value xml:lang="nl">Nieuw bericht</value>
         <value xml:lang="pt-BR">Nova mensagem</value>
-        <value xml:lang="ro">Nou Mesaj</value>
+        <value xml:lang="ro">Mesaj Nou</value>
         <value xml:lang="ru">Новое сообщение</value>
         <value xml:lang="th">ข้อความใหม่</value>
         <value xml:lang="vi">Thông điệp mới</value>
@@ -4789,6 +4871,7 @@
         <value xml:lang="ja">注文取り寄せ通知</value>
         <value xml:lang="nl">Notificatie bestelling retour</value>
         <value xml:lang="pt-BR">Notificação de pedido a ser processado</value>
+        <value xml:lang="ro">Notificare de comandă în așteptare</value>
         <value xml:lang="th">พบว่าไม่สามรถส่งสินค้าตามรายการสั่งซื้อได้ในขณะนั้นเนื่องจากสินค้าหมด</value>
         <value xml:lang="vi">Thông báo đơn hàng trả về (Backorder)</value>
         <value xml:lang="zh">订单延期交货通知</value>
@@ -4803,6 +4886,7 @@
         <value xml:lang="ja">注文変更通知</value>
         <value xml:lang="nl">Notificatie bestelling gewijzigd</value>
         <value xml:lang="pt-BR">Notificação de alteração de pedido</value>
+        <value xml:lang="ro">Notificare de modificare a comenzii</value>
         <value xml:lang="th">พบว่ามีการเปลี่ยนแปลงรายการสั่งซื้อสินค้า</value>
         <value xml:lang="vi">Thông báo thay đổi đặt hàng</value>
         <value xml:lang="zh">订单变更通知</value>
@@ -4818,7 +4902,7 @@
         <value xml:lang="ja">注文完了通知</value>
         <value xml:lang="nl">Notificatie bestelling gereed</value>
         <value xml:lang="pt-BR">Notificação de encerramento de pedido</value>
-        <value xml:lang="ro">Notifica comanda Completata</value>
+        <value xml:lang="ro">Notificare comandă Completată</value>
         <value xml:lang="ru">Уведомление о завершении заказа</value>
         <value xml:lang="th">รายการสั่งซื้อสินค้านี้เสร็จสมบูรณ์แล้ว</value>
         <value xml:lang="vi">Thông báo đặt hàng hoàn thành</value>
@@ -4835,7 +4919,7 @@
         <value xml:lang="ja">注文の確認</value>
         <value xml:lang="nl">Bevestiging bestelling</value>
         <value xml:lang="pt-BR">Confirmação de pedido</value>
-        <value xml:lang="ro">Confirmare Comanda</value>
+        <value xml:lang="ro">Confirmare Comandă</value>
         <value xml:lang="ru">Подтверждение заказа</value>
         <value xml:lang="th">ยืนยันการทำรายการสั่งซื้อสินค้า</value>
         <value xml:lang="vi">Xác nhận đặt hàng</value>
@@ -4851,6 +4935,7 @@
         <value xml:lang="ja">注文確認通知</value>
         <value xml:lang="nl">Notificatie bestelling bevestigd</value>
         <value xml:lang="pt-BR">Notificação de confirmação de pedido</value>
+        <value xml:lang="ro">Notificare de confirmare a comenzii</value>
         <value xml:lang="vi">Thông báo xác nhận đặt hàng</value>
         <value xml:lang="zh">订单确认通知</value>
         <value xml:lang="zh-TW">訂單確認通知</value>
@@ -4868,7 +4953,7 @@
         <value xml:lang="nl">Bestelhistorie</value>
         <value xml:lang="pt-BR">Histórico de pedidos</value>
         <value xml:lang="pt-PT">Historial de Encomendas</value>
-        <value xml:lang="ro">Istoric Comanda</value>
+        <value xml:lang="ro">Istoric Comenzi</value>
         <value xml:lang="ru">Заказы</value>
         <value xml:lang="th">ข้อมูลการสั่งซื้อสินค้า</value>
         <value xml:lang="vi">Lịch sử đặt hàng</value>
@@ -4884,6 +4969,7 @@
         <value xml:lang="ja">支払再試行通知</value>
         <value xml:lang="nl">Notificatie nieuwe poging betaling</value>
         <value xml:lang="pt-BR">Notificação de nova tentativa de pagamento</value>
+        <value xml:lang="ro">Notificare de reîncercare a plății</value>
         <value xml:lang="th">พบการชำระการสั่งซื้อสินค้าใหม่</value>
         <value xml:lang="vi">Thông báo xử lý lại thanh toán</value>
         <value xml:lang="zh">支付重试通知</value>
@@ -4902,7 +4988,7 @@
         <value xml:lang="nl">Bestelling status</value>
         <value xml:lang="pt-BR">Estado do pedido</value>
         <value xml:lang="pt-PT">Estado das Encomendas</value>
-        <value xml:lang="ro">Stare  Comanda </value>
+        <value xml:lang="ro">Stare Comanda</value>
         <value xml:lang="ru">Статус заказа</value>
         <value xml:lang="th">สถานะการสั่งซื้อสินค้า</value>
         <value xml:lang="vi">Trạng thái đặt hàng</value>
@@ -4922,7 +5008,7 @@
         <value xml:lang="nl">Bestelling overzicht - We danken u voor uw bestelling!</value>
         <value xml:lang="pt-BR">Resumo do pedido - Muito Obrigado por seu pedido</value>
         <value xml:lang="pt-PT">Resumo das Encomendas - Gratos pela sua encomenda!</value>
-        <value xml:lang="ro">Rezumat Comanda - Multumim pentru comanda ta!</value>
+        <value xml:lang="ro">Rezumat Comandă - Mulțumim pentru comanda ta!</value>
         <value xml:lang="ru">Итоги по заказу - спасибо за ваш заказ!</value>
         <value xml:lang="th">สรุปการสั่งซื้อสินค้า - ขอบคุณสำหรับการทำรายการสั่งซื้อสินค้า!</value>
         <value xml:lang="vi">Cảm ơn bạn đã đặt hàng. Đơn đặt hàng toàn bộ như sau. </value>
@@ -4941,7 +5027,7 @@
         <value xml:lang="nl">Product overzicht</value>
         <value xml:lang="pt-BR">Resenha do produto</value>
         <value xml:lang="pt-PT">Revisão do Produto</value>
-        <value xml:lang="ro">Revizie Produs</value>
+        <value xml:lang="ro">Recenzie Produs</value>
         <value xml:lang="ru">Обзор продукта</value>
         <value xml:lang="th">ตรวจสอบสินค้า</value>
         <value xml:lang="vi">Đánh giá sản phẩm</value>
@@ -4960,7 +5046,7 @@
         <value xml:lang="ja">プロファイル評価</value>
         <value xml:lang="nl">Profiel enquete</value>
         <value xml:lang="pt-BR">Perfil da enquete</value>
-        <value xml:lang="ro">Cadru General</value>
+        <value xml:lang="ro">Sondaj profil</value>
         <value xml:lang="ru">Обзор профиля</value>
         <value xml:lang="th">สำรวจประวัติ</value>
         <value xml:lang="vi">Hồ sơ khảo sát</value>
@@ -4999,7 +5085,7 @@
         <value xml:lang="ja">サイトを検索</value>
         <value xml:lang="nl">Zoek sites</value>
         <value xml:lang="pt-BR">Procurar sites</value>
-        <value xml:lang="ro">Cauta Situri</value>
+        <value xml:lang="ro">Caută Site-uri</value>
         <value xml:lang="ru">Поисковые сайты</value>
         <value xml:lang="th">ค้นหาสถานที่</value>
         <value xml:lang="vi">Tiêu đề tìm kiếm</value>
@@ -5033,6 +5119,7 @@
         <value xml:lang="ja">発送完了通知</value>
         <value xml:lang="nl">Notificatie verzending gereed</value>
         <value xml:lang="pt-BR">Notificação de envio efetuado</value>
+        <value xml:lang="ro">Notificare de finalizare a expedierii</value>
         <value xml:lang="th">การชำระเงินเสร็จสมบูรณ์แล้ว</value>
         <value xml:lang="vi">Thông báo đã hoàn thành giao hàng</value>
         <value xml:lang="zh">送货完成通知</value>
@@ -5049,7 +5136,7 @@
         <value xml:lang="ja">発送先情報</value>
         <value xml:lang="nl">Verzendinformatie</value>
         <value xml:lang="pt-BR">Dados de envio</value>
-        <value xml:lang="ro">Expediere </value>
+        <value xml:lang="ro">Informații livrare</value>
         <value xml:lang="ru">Информация по поставке</value>
         <value xml:lang="th">ข้อมูลการขนส่ง</value>
         <value xml:lang="vi">Thông tin giao hàng</value>
@@ -5067,7 +5154,7 @@
         <value xml:lang="ja">発送オプション</value>
         <value xml:lang="nl">Verzendopties</value>
         <value xml:lang="pt-BR">Opções de envio</value>
-        <value xml:lang="ro">Optiuni Expediere </value>
+        <value xml:lang="ro">Opțiuni Livrare</value>
         <value xml:lang="ru">Параметры поставки</value>
         <value xml:lang="th">ลักษณะการขนส่ง</value>
         <value xml:lang="vi">Tùy chọn giao hàng</value>
@@ -5088,7 +5175,7 @@
         <value xml:lang="nl">Winkelwagen</value>
         <value xml:lang="pt-BR">Carrinho</value>
         <value xml:lang="pt-PT">Cesto De Compras</value>
-        <value xml:lang="ro">Cos Cumparari</value>
+        <value xml:lang="ro">Coș Cumpărături</value>
         <value xml:lang="ru">Корзина покупок</value>
         <value xml:lang="th">การซื้อสินค้าลงตะกร้า</value>
         <value xml:lang="vi">Giỏ hàng</value>
@@ -5105,7 +5192,7 @@
         <value xml:lang="ja">発送時にアイテムを分割</value>
         <value xml:lang="nl">Splits items op voor verzending</value>
         <value xml:lang="pt-BR">Dividir itens em grupos para o envio</value>
-        <value xml:lang="ro">Divide linii pe expedieri </value>
+        <value xml:lang="ro">Împarte articolele în mai multe livrări</value>
         <value xml:lang="ru">Разделить позиции для доставки</value>
         <value xml:lang="th">แยกสินค้าเพื่อการขนส่ง</value>
         <value xml:lang="vi">Phân chia hàng hóa để vận chuyển</value>
@@ -5118,6 +5205,7 @@
         <value xml:lang="fr">Résultats de la recherche par étiquette</value>
         <value xml:lang="ja">タグ結果</value>
         <value xml:lang="nl">Zoekresultaat tags</value>
+        <value xml:lang="ro">Rezultate eticheta</value>
         <value xml:lang="vi">Đánh dấu (Tag) kết quả</value>
         <value xml:lang="zh">标签结果</value>
         <value xml:lang="zh-TW">標籤結果</value>
@@ -5183,6 +5271,7 @@
         <value xml:lang="ja">見積の表示</value>
         <value xml:lang="nl">Bekijk offerte</value>
         <value xml:lang="pt-BR">Visualizar citação</value>
+        <value xml:lang="ro">Vezi oferta</value>
         <value xml:lang="vi">Xem báo giá</value>
         <value xml:lang="zh">浏览询价</value>
         <value xml:lang="zh-TW">檢視報價</value>
@@ -5190,6 +5279,7 @@
     <property key="ThankYouForContactingUs">
         <value xml:lang="en">Thank You for contacting us.</value>
         <value xml:lang="nl">Bedankt dat u contact met ons opnam.</value>
+        <value xml:lang="ro">Vă mulțumim că ne-ați contactat.</value>
         <value xml:lang="zh">感谢您与我们联系！</value>
     </property>
 </resource>


### PR DESCRIPTION
Many of the existing labels where wrong. Fixed those. And also added missing labels for 'ro' locale.

Thanks: Tomislav Preksavec for the python script that uses Google Translate to suggest translations(see
https://github.com/mikrotron-zg/poslotron-tools/tree/main/translatr)