### PR TITLE
Fixed: commented out a test suite declaration pointing to an empty test suite file

### DIFF
--- a/rest-api/ofbiz-component.xml
+++ b/rest-api/ofbiz-component.xml
@@ -30,7 +30,9 @@ under the License.
     <!-- service resources: model(s), eca(s) and group definitions -->
     <service-resource type="model" loader="main" location="servicedef/services.xml"/>
 
+    <!--
     <test-suite loader="main" location="testdef/rest-apiTests.xml"/>
+    -->
 
     <!-- web applications; will be mounted when using the embedded container -->
     <webapp name="rest-api"


### PR DESCRIPTION
Since there are no tests defined for the rest-api component, the system complained that the test file definition is not valid.