### PR TITLE
Fixed : Remove obsolete enableRemoteStreaming from solrconfig.xml (OFBIZ-13368)

### DIFF
--- a/solr/home/solrdefault/conf/solrconfig.xml
+++ b/solr/home/solrdefault/conf/solrconfig.xml
@@ -699,14 +699,8 @@
          Solr components, but may be useful when developing custom
          plugins.
 
-         *** WARNING ***
-         The settings below authorize Solr to fetch remote files, You
-         should make sure your system has some authentication before
-         using enableRemoteStreaming="true"
-
       -->
-    <requestParsers enableRemoteStreaming="true"
-                    multipartUploadLimitInKB="2048000"
+    <requestParsers multipartUploadLimitInKB="2048000"
                     formdataUploadLimitInKB="2048"
                     addHttpRequestToContext="false"/>
 


### PR DESCRIPTION
Since Solr 8.11.3 the variable 'enableRemoteStreaming' controlling the streaming of remoteURLs has been removed from solrconfig.xml and is now set via SystemPropertys due to security concerns. References in solrconfig.xml are ignored. For more Information see SOLR-14853.
(OFBIZ-13368)
