### PR TITLE
Improved: Bump minor versions of dependencies

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 dependencies {
-    pluginLibsCompile 'org.apache.tomcat.embed:tomcat-embed-websocket:9.0.110' // Moving to Tomcat 10 needs more work or maybe removing websocket that does not work anyway, see OFBIZ-7073
+    pluginLibsCompile 'org.apache.tomcat.embed:tomcat-embed-websocket:9.0.116' // Moving to Tomcat 10 needs more work or maybe removing websocket that does not work anyway, see OFBIZ-7073
 }
 
 node {

--- a/ldap/build.gradle
+++ b/ldap/build.gradle
@@ -26,7 +26,7 @@
 //                LdapEntry entry = new LdapEntry(username);
 //                                                ^
 dependencies {
-    pluginLibsCompile 'org.apereo.cas:cas-server-support-ldap-core:6.6.15' // 7.x+ requires Java 21
+    pluginLibsCompile 'org.apereo.cas:cas-server-support-ldap-core:6.6.15.2' // 7.x+ requires Java 21
 }
 
 configurations.all {

--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -17,11 +17,10 @@
  * under the License.
  */
 dependencies {
-    // 1. Remember to change the version LUCENE_VERSION in SearchWorker class when upgrading.
-    // 2. luceneMatchVersion should be updated in solrconfig.xml
-    // 3. Also Solr et Lucene should use the same version, 
-    pluginLibsCompile 'org.apache.lucene:lucene-core:9.8.0'
-    pluginLibsCompile 'org.apache.lucene:lucene-queryparser:9.8.0'
+    // solr and lucene should be updated together
+    // luceneMatchVersion should be updated in solrconfig.xml
+    pluginLibsCompile 'org.apache.lucene:lucene-core:9.12.3'
+    pluginLibsCompile 'org.apache.lucene:lucene-queryparser:9.12.3'
 //    pluginLibsCompile 'org.apache.lucene:lucene-analyzers-common:9.8.0'
-    pluginLibsCompile 'org.apache.lucene:lucene-analysis-common:9.8.0'
+    pluginLibsCompile 'org.apache.lucene:lucene-analysis-common:9.12.3'
 }

--- a/rest-api/build.gradle
+++ b/rest-api/build.gradle
@@ -23,13 +23,13 @@ project.rootProject.configurations.all {
 }
 
 dependencies {
-    pluginLibsCompile 'org.glassfish.jersey.containers:jersey-container-servlet:3.1.3'
-    pluginLibsCompile 'org.glassfish.jersey.inject:jersey-hk2:3.1.3'
-    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-multipart:3.1.3'
-    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-json-jackson:3.1.3'
-    pluginLibsCompile 'io.swagger.core.v3:swagger-jaxrs2:2.2.20'
-    pluginLibsCompile 'io.swagger.core.v3:swagger-jaxrs2-servlet-initializer:2.2.20'
-    pluginLibsCompile 'io.swagger.core.v3:swagger-annotations:2.2.20'
+    pluginLibsCompile 'org.glassfish.jersey.containers:jersey-container-servlet:3.1.11'
+    pluginLibsCompile 'org.glassfish.jersey.inject:jersey-hk2:3.1.11'
+    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-multipart:3.1.11'
+    pluginLibsCompile 'org.glassfish.jersey.media:jersey-media-json-jackson:3.1.11'
+    pluginLibsCompile 'io.swagger.core.v3:swagger-jaxrs2:2.2.45'
+    pluginLibsCompile 'io.swagger.core.v3:swagger-jaxrs2-servlet-initializer:2.2.45'
+    pluginLibsCompile 'io.swagger.core.v3:swagger-annotations:2.2.45'
 }
 
 task install {

--- a/solr/build.gradle
+++ b/solr/build.gradle
@@ -21,15 +21,15 @@ dependencies {
     // 2. luceneMatchVersion should be updated in solrconfig.xml
     // 3. Also Solr et Lucene should use the same version,
     // TODO : upgrade when jakarte update has been done ?
-    pluginLibsCompile 'org.apache.solr:solr-core:9.8.0'
+    pluginLibsCompile 'org.apache.solr:solr-core:9.10.1'
 //    pluginLibsCompile 'org.apache.solr:solr-core:8.11.3'
-    pluginLibsCompile 'com.google.guava:guava:28.0-jre'
+    pluginLibsCompile 'com.google.guava:guava:28.2-jre'
 }
 
 configurations.all {
     resolutionStrategy {
       dependencySubstitution {
-          substitute module('com.google.guava:guava') using module('com.google.guava:guava:28.0-jre')
+          substitute module('com.google.guava:guava') using module('com.google.guava:guava:28.2-jre')
       }
     }
 }

--- a/solr/home/solrdefault/conf/solrconfig.xml
+++ b/solr/home/solrdefault/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>9.8.0</luceneMatchVersion>
+  <luceneMatchVersion>9.12.3</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in


### PR DESCRIPTION
Bumps 1 update in the /example directory: org.apache.tomcat.embed:tomcat-embed-websocket.
Bumps 1 update in the /ldap directory: [org.apereo.cas:cas-server-support-ldap-core](https://github.com/apereo/cas).
Bumps 1 update in the /lucene directory: org.apache.lucene:lucene-core.
Bumps 4 updates in the /rest-api directory: org.glassfish.jersey.containers:jersey-container-servlet, org.glassfish.jersey.inject:jersey-hk2, org.glassfish.jersey.media:jersey-media-multipart and io.swagger.core.v3:swagger-jaxrs2.
Bumps 2 updates in the /solr directory: org.apache.solr:solr-core and [com.google.guava:guava](https://github.com/google/guava).

Updates `org.apache.tomcat.embed:tomcat-embed-websocket` from 9.0.110 to 9.0.116

Updates `org.apereo.cas:cas-server-support-ldap-core` from 6.6.15 to 6.6.15.2
- [Release notes](https://github.com/apereo/cas/releases)
- [Commits](https://github.com/apereo/cas/compare/v6.6.15...v6.6.15.2)

Updates `org.apache.lucene:lucene-core` from 9.8.0 to 9.12.3

Updates `org.apache.lucene:lucene-queryparser` from 9.8.0 to 9.12.3

Updates `org.apache.lucene:lucene-analysis-common` from 9.8.0 to 9.12.3

Updates `org.glassfish.jersey.containers:jersey-container-servlet` from 3.1.3 to 3.1.11

Updates `org.glassfish.jersey.inject:jersey-hk2` from 3.1.3 to 3.1.11

Updates `org.glassfish.jersey.media:jersey-media-multipart` from 3.1.3 to 3.1.11

Updates `org.glassfish.jersey.media:jersey-media-json-jackson` from 3.1.3 to 3.1.11

Updates `io.swagger.core.v3:swagger-jaxrs2` from 2.2.20 to 2.2.45

Updates `io.swagger.core.v3:swagger-jaxrs2-servlet-initializer` from 2.2.20 to 2.2.45

Updates `io.swagger.core.v3:swagger-annotations` from 2.2.20 to 2.2.45

Updates `org.apache.solr:solr-core` from 9.8.0 to 9.10.1

Updates `com.google.guava:guava` from 28.0-jre to 28.2-jre
- [Release notes](https://github.com/google/guava/releases)
- [Commits](https://github.com/google/guava/commits)

---
updated-dependencies:
- dependency-name: org.apache.tomcat.embed:tomcat-embed-websocket dependency-version: 9.0.116 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: org.apereo.cas:cas-server-support-ldap-core dependency-version: 6.6.15.2 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: org.apache.lucene:lucene-core dependency-version: 9.12.3 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: all-dependencies
- dependency-name: org.apache.lucene:lucene-queryparser dependency-version: 9.12.3 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: all-dependencies
- dependency-name: org.apache.lucene:lucene-analysis-common dependency-version: 9.12.3 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: all-dependencies
- dependency-name: org.glassfish.jersey.containers:jersey-container-servlet dependency-version: 3.1.11 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: org.glassfish.jersey.inject:jersey-hk2 dependency-version: 3.1.11 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: org.glassfish.jersey.media:jersey-media-multipart dependency-version: 3.1.11 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: org.glassfish.jersey.media:jersey-media-json-jackson dependency-version: 3.1.11 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: io.swagger.core.v3:swagger-jaxrs2 dependency-version: 2.2.45 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: io.swagger.core.v3:swagger-jaxrs2-servlet-initializer dependency-version: 2.2.45 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: io.swagger.core.v3:swagger-annotations dependency-version: 2.2.45 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: org.apache.solr:solr-core dependency-version: 9.10.1 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: all-dependencies
- dependency-name: com.google.guava:guava dependency-version: 28.2-jre dependency-type: direct:production dependency-group: all-dependencies