### PR TITLE
FIXED: Issue on canceling an item from multi item order ecommerce ord…

### DIFF
--- a/ecommerce/data/EcommerceSecurityData.xml
+++ b/ecommerce/data/EcommerceSecurityData.xml
@@ -19,4 +19,7 @@ under the License.
 -->
 <entity-engine-xml>
     <SecurityGroup description="Customer user of ECOMMERCE Limited access to own account" groupId="ECOMMERCE_CUSTOMER"/>
+    <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="ECOMMERCE_CUSTOMER" permissionId="ORDERMGR_ROLE_VIEW"/>
+    <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="ECOMMERCE_CUSTOMER" permissionId="ORDERMGR_ROLE_CREATE"/>
+    <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="ECOMMERCE_CUSTOMER" permissionId="ORDERMGR_ROLE_UPDATE"/>
 </entity-engine-xml>

--- a/ecommerce/template/order/OrderItems.ftl
+++ b/ecommerce/template/order/OrderItems.ftl
@@ -33,6 +33,7 @@ under the License.
           <form name="addCommonToCartForm" action="<@ofbizUrl>addordertocart/orderstatus</@ofbizUrl>" method="post">
         <input type="hidden" name="add_all" value="false" />    
             <input type="hidden" name="orderId" value="${orderHeader.orderId}" />
+            <input type="hidden" name="orderItemSeqId" value="" />
     </#if>
   <div class="card-header">
     <strong>
@@ -268,9 +269,8 @@ under the License.
             </td>
             <td>
               <a
-                href="javascript:document.addCommonToCartForm.action='<@ofbizUrl>cancelOrderItem</@ofbizUrl>';document.addCommonToCartForm.submit()"
+                href="javascript:document.addCommonToCartForm.action='<@ofbizUrl>cancelOrderItem</@ofbizUrl>';document.addCommonToCartForm.orderItemSeqId.value='${orderItem.orderItemSeqId}';document.addCommonToCartForm.submit()"
                 class="d-inline-block mt-2">${uiLabelMap.CommonCancel}</a>
-              <input type="hidden" name="orderItemSeqId" value="${orderItem.orderItemSeqId}"/>
             </td>
           </tr>
         </#if>


### PR DESCRIPTION

FIXED: Issue on canceling an item from multi item order ecommerce order view page by customer.

(OFBIZ-12103)

Explanation: Customer was not able to cancel item from multi item order from ecommerce order view page. Also, given the ORDERMGR_ROLE_VIEW, ORDERMGR_ROLE_CREATE and ORDERMGR_ROLE_UPDATE permissions to ECOMMERCE_CUSTOMER so that it can pass permission checks of this process.

Thanks: Rashi Dhagat, Pradeep Choudhary  for sharing details and contribution. Also thanks to Jacques Le Roux for validating initial patch.
