### PR TITLE
Fixed: Add license header to ServiceContextCleanupFilter.java

### DIFF
--- a/rest-api/src/main/java/org/apache/ofbiz/ws/rs/filters/ServiceContextCleanupFilter.java
+++ b/rest-api/src/main/java/org/apache/ofbiz/ws/rs/filters/ServiceContextCleanupFilter.java
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package org.apache.ofbiz.ws.rs.filters;
 
 import jakarta.ws.rs.container.ContainerRequestContext;


### PR DESCRIPTION
In the [output](https://nightlies.apache.org/ofbiz/trunk/rat-output.html) of the latest run of the buildbot builder ofbizTrunkFrameworkRat, it is reported that the file

rest-api/src/main/java/org/apache/ofbiz/ws/rs/filters/ServiceContextCleanupFilter.java

has an unapproved license. The reason is that the license header is missing. 
