### PR TITLE
Fixed PriCat Excel upload NullPointerException (OFBIZ-12325)

### DIFF
--- a/pricat/src/main/java/org/apache/ofbiz/htmlreport/AbstractReportThread.java
+++ b/pricat/src/main/java/org/apache/ofbiz/htmlreport/AbstractReportThread.java
@@ -165,6 +165,7 @@ public abstract class AbstractReportThread extends Thread implements InterfaceRe
 
         HtmlReport report = HtmlReport.getInstance(request, response);
         report.setParamThread(getUUID().toString());
+        this.report = report;
     }
 
     /**
@@ -174,6 +175,7 @@ public abstract class AbstractReportThread extends Thread implements InterfaceRe
 
         HtmlReport report = HtmlReport.getInstance(request, response, writeHtml, isTransient);
         report.setParamThread(getUUID().toString());
+        this.report = report;
     }
 
     /**
@@ -188,6 +190,7 @@ public abstract class AbstractReportThread extends Thread implements InterfaceRe
                                   String logFileName) {
         HtmlReport report = HtmlReport.getInstance(request, response, writeHtml, isTransient, logFileName);
         report.setParamThread(getUUID().toString());
+        this.report = report;
     }
 
     /**


### PR DESCRIPTION
Fixed: Fixed PriCat Excel upload NullPointerException
(OFBIZ-12325)

Properly assign the instantiated HtmlReport to the 'report' field in AbstractReportThread.java inside the initHtmlReport overloads. This prevents NullPointerException during Thread initialization when calling getReport().
