### PR TITLE
Restore /rest-api directory in dependabot.yml for release24.09 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,7 @@ updates:
       - "/ldap"
       - "/lucene"
       - "/pricat"
+      - "/rest-api"
     target-branch: "release24.09"
     schedule:
       interval: "daily"


### PR DESCRIPTION
The rest-api plugin was moved into the framework only on the trunk branch; it still exists as a standalone plugin in the release24.09 branch.