### PR TITLE
Remove deprecated and defunct third-party payment gateway integrations and their references (OFBIZ-13446)

### DIFF
--- a/ecommerce/data/DemoRentalProduct.xml
+++ b/ecommerce/data/DemoRentalProduct.xml
@@ -42,8 +42,7 @@ headerLogo="/images/opentravelsystem_logo.jpg"
     <ProductStorePaymentSetting productStoreId="RentalStore" paymentMethodTypeId="EFT_ACCOUNT" paymentServiceTypeEnumId="PRDS_PAY_AUTH" paymentService="alwaysApproveEFTProcessor" paymentCustomMethodId="EFT_AUTH_ALWAYSAPPRO"/>
     <ProductStorePaymentSetting productStoreId="RentalStore" paymentMethodTypeId="GIFT_CARD" paymentServiceTypeEnumId="PRDS_PAY_AUTH" paymentService="alwaysApproveGCProcessor" paymentCustomMethodId="GIFT_AUTH_ALWAYSAPPR"/>
     <ProductStorePaymentSetting productStoreId="RentalStore" paymentMethodTypeId="GIFT_CARD" paymentServiceTypeEnumId="PRDS_PAY_RELEASE" paymentService="testGCRelease" paymentCustomMethodId="GIFT_RELEASE_TEST"/>
-    <ProductStorePaymentSetting productStoreId="RentalStore" paymentMethodTypeId="EXT_PAYPAL" paymentServiceTypeEnumId="PRDS_PAY_EXTERNAL" paymentService="" paymentCustomMethodId="" paymentGatewayConfigId="PAYPAL_CONFIG"/>
-    <ProductStorePaymentSetting productStoreId="RentalStore" paymentMethodTypeId="EXT_WORLDPAY" paymentServiceTypeEnumId="PRDS_PAY_EXTERNAL" paymentService="" paymentCustomMethodId="" paymentGatewayConfigId="WORLDPAY_CONFIG"/>
+
 
     <ProductStoreEmailSetting productStoreId="RentalStore" emailType="PRDS_ODR_CONFIRM" bodyScreenLocation="component://ecommerce/widget/EmailOrderScreens.xml#OrderConfirmNotice" xslfoAttachScreenLocation="component://ecommerce/widget/EmailOrderScreens.xml#OrderConfirmNoticePdf" subject="OFBiz Demo - Order Confirmation #${orderId}" bccAddress="ofbiztest@example.com" fromAddress="ofbiztest@example.com"/>
     <ProductStoreEmailSetting productStoreId="RentalStore" emailType="PRDS_ODR_COMPLETE" bodyScreenLocation="component://ecommerce/widget/EmailOrderScreens.xml#OrderCompleteNotice" subject="OFBiz Demo - Your Order Is Complete #${orderId}" fromAddress="ofbiztest@example.com"/>

--- a/ecommerce/template/cart/MicroCart.ftl
+++ b/ecommerce/template/cart/MicroCart.ftl
@@ -66,15 +66,6 @@ under the License.
       <li class="list-inline-item disabled" id="onePageCheckoutDisabled" style="display:none">
         [${uiLabelMap.EcommerceOnePageCheckout}]
       </li>
-      <#if shoppingCart?has_content && (shoppingCart.getGrandTotal() > 0)>
-        <li class="list-inline-item" id="microCartPayPalCheckout">
-          <a href="<@ofbizUrl>setPayPalCheckout</@ofbizUrl>">
-            <img src="https://www.paypal.com/${initialLocaleComplete}/i/btn/btn_xpressCheckout.gif"
-                alt="[PayPal Express Checkout]"
-                onError="this.onerror=null;this.src='https://www.paypal.com/en_US/i/btn/btn_xpressCheckout.gif'"/>
-          </a>
-        </li>
-      </#if>
     <#else>
       <li class="list-inline-item disabled">[${uiLabelMap.OrderCheckoutQuick}]</li>
       <li class="list-inline-item disabled">[${uiLabelMap.EcommerceOnePageCheckout}]</li>

--- a/ecommerce/webapp/ecommerce/WEB-INF/controller.xml
+++ b/ecommerce/webapp/ecommerce/WEB-INF/controller.xml
@@ -424,7 +424,6 @@ under the License.
         <security https="true" auth="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="checkExternalCheckout"/>
         <response name="success" type="view" value="paymentinformation"/>
-        <response name="paypal" type="request" value="setPayPalCheckout"/>
     </request-map>
 
     <request-map uri="enterCreditCardAndBillingAddress">
@@ -783,8 +782,6 @@ under the License.
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="checkExternalPayment"/>
         <response name="none" type="request" value="emailorder"/>
         <response name="offline" type="request" value="emailorder"/>
-        <response name="worldpay" type="request" value="callWorldPay"/>
-        <response name="paypal" type="request" value="callPayPal"/>
         <response name="billact" type="request" value="emailorder"/>
         <response name="cod" type="request" value="emailorder"/>
         <response name="error" type="view" value="checkoutreview"/>
@@ -795,69 +792,6 @@ under the License.
         <event type="service" path="async" invoke="sendOrderConfirmation"/>
         <response name="success" type="view" value="ordercomplete"/>
         <response name="error" type="view" value="ordercomplete"/>
-    </request-map>
-
-    <request-map uri="callWorldPay">
-        <security https="true" auth="false" direct-request="false"/>
-        <event type="java" path="org.apache.ofbiz.accounting.thirdparty.worldpay.WorldPayEvents" invoke="worldPayRequest"/>
-        <response name="success" type="none"/>
-        <response name="error" type="view" value="checkoutreview"/>
-    </request-map>
-    <request-map uri="worldPayNotify">
-        <security https="false" auth="false"/>
-        <event type="java" path="org.apache.ofbiz.accounting.thirdparty.worldpay.WorldPayEvents" invoke="worldPayNotify"/>
-        <response name="success" type="none"/>
-        <response name="error" type="view" value="checkoutreview"/>
-    </request-map>
-
-    <request-map uri="callPayPal">
-        <security https="true" auth="false" direct-request="false"/>
-        <event type="java" path="org.apache.ofbiz.accounting.thirdparty.paypal.PayPalEvents" invoke="callPayPal"/>
-        <response name="success" type="none"/>
-        <response name="error" type="view" value="checkoutreview"/>
-    </request-map>
-    <request-map uri="payPalNotify">
-        <security https="false" auth="false"/>
-        <event type="java" path="org.apache.ofbiz.accounting.thirdparty.paypal.PayPalEvents" invoke="payPalIPN"/>
-        <response name="success" type="none"/>
-        <response name="error" type="none"/>
-    </request-map>
-    <request-map uri="payPalCancel">
-        <security https="true" auth="false"/>
-        <event type="java" path="org.apache.ofbiz.accounting.thirdparty.paypal.PayPalEvents" invoke="cancelPayPalOrder"/>
-        <response name="success" type="view" value="main"/>
-        <response name="error" type="view" value="main"/>
-    </request-map>
-
-    <!-- PayPal Express Checkout Requests -->
-    <request-map uri="setPayPalCheckout">
-        <security auth="false" https="true"/>
-        <event type="java" path="org.apache.ofbiz.order.thirdparty.paypal.ExpressCheckoutEvents" invoke="setExpressCheckout"/>
-        <response name="success" type="request" value="payPalCheckoutRedirect"/>
-        <response name="error" type="view-last"/>
-    </request-map>
-    <request-map uri="payPalCheckoutRedirect">
-        <security auth="false" https="true"/>
-        <event type="java" path="org.apache.ofbiz.order.thirdparty.paypal.ExpressCheckoutEvents" invoke="expressCheckoutRedirect"/>
-        <response name="success" type="none"/>
-        <response name="error" type="view-last"/>
-    </request-map>
-    <request-map uri="payPalCheckoutReturn">
-        <security auth="false" https="true"/>
-        <event type="java" path="org.apache.ofbiz.order.thirdparty.paypal.ExpressCheckoutEvents" invoke="getExpressCheckoutDetails"/>
-        <response name="success" type="request" value="reviewOrder"/>
-        <response name="error" type="view-last" value="main"/>
-    </request-map>
-    <request-map uri="payPalCheckoutCancel">
-        <security auth="false" https="true"/>
-        <event type="java" path="org.apache.ofbiz.order.thirdparty.paypal.ExpressCheckoutEvents" invoke="expressCheckoutCancel"/>
-        <response name="success" type="view-last"/>
-    </request-map>
-    <request-map uri="payPalCheckoutUpdate">
-        <description>Handles callbacks from PayPal's Express Checkout Instant Update API</description>
-        <security auth="false" https="false"/>
-        <event type="java" path="org.apache.ofbiz.order.thirdparty.paypal.ExpressCheckoutEvents" invoke="expressCheckoutUpdate"/>
-        <response name="success" type="none"/>
     </request-map>
 
     <request-map uri="quickadd">
@@ -1712,8 +1646,6 @@ under the License.
         <response name="none" type="request" value="emailorder"/>
         <!-- these are not yet supported
         <response name="offline" type="request" value="emailorder"/>
-        <response name="worldpay" type="request" value="callWorldPay"/>
-        <response name="paypal" type="request" value="callPayPal"/>
         <response name="billact" type="request" value="emailorder"/>
         <response name="cod" type="request" value="emailorder"/> -->
         <response name="error" type="view" value="OnePageCheckout"/>


### PR DESCRIPTION
Improved: Remove deprecated and defunct third-party payment gateway integrations and their references
(OFBIZ-13446)

Changes include:
- Removed 11 PayPal and WorldPay controller request-maps from ecommerce/webapp/ecommerce/WEB-INF/controller.xml (callPayPal, payPalNotify, payPalCancel, setPayPalCheckout, payPalCheckoutRedirect, payPalCheckoutReturn, payPalCheckoutCancel, payPalCheckoutUpdate, callWorldPay, worldPayNotify) along with their references in setPaymentInformation and checkExternalPayment request-maps
- Removed PayPal Express Checkout button from ecommerce/template/cart/MicroCart.ftl
- Removed broken EXT_PAYPAL and EXT_WORLDPAY ProductStorePaymentSetting demo data rows from ecommerce/data/DemoRentalProduct.xml that referenced deleted gateway configs