### PR TITLE
Fixed: Remove leftover references from deleted shipping carrier integrations (OFBIZ-7935)

### DIFF
--- a/birt/webapp/facility/WEB-INF/web.xml
+++ b/birt/webapp/facility/WEB-INF/web.xml
@@ -93,20 +93,9 @@ under the License.
         <servlet-class>org.apache.ofbiz.webapp.control.ControlServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-    <servlet>
-        <description>Mock USPS Webtools API Servlet</description>
-        <display-name>ShippingAPI</display-name>
-        <servlet-name>ShippingAPI</servlet-name>
-        <servlet-class>org.apache.ofbiz.shipment.thirdparty.usps.UspsMockApiServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
     <servlet-mapping>
         <servlet-name>ControlServlet</servlet-name>
         <url-pattern>/control/*</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>ShippingAPI</servlet-name>
-        <url-pattern>/ShippingAPI.dll</url-pattern>
     </servlet-mapping>
 
     <welcome-file-list>

--- a/ecommerce/template/order/OrderHeader.ftl
+++ b/ecommerce/template/order/OrderHeader.ftl
@@ -314,7 +314,6 @@ under the License.
           <#if trackingNumber?has_content || orderShipmentInfoSummaryList?has_content>
             <li>
               ${uiLabelMap.OrderTrackingNumber}
-              <#-- TODO: add links to UPS/FEDEX/etc based on carrier partyId  -->
               <#if shipGroup.trackingNumber?has_content>
                 ${shipGroup.trackingNumber}
               </#if>


### PR DESCRIPTION
Fixed: Remove leftover references from deleted shipping carrier integrations
(OFBIZ-7935)

Follow-up cleanup after PR #1335 removed DHL, FedEx, UPS, and USPS shipping carrier integrations. Removes:
- Dead UspsMockApiServlet definition and mapping from birt plugin web.xml
- Stale TODO comment referencing UPS/FedEx in ecommerce OrderHeader.ftl