### PR TITLE
Fixed: Type mismatch when filtering InventoryItem by availableToPromiseTotal in FixedAssetMaintServices (OFBIZ-13448)

### DIFF
--- a/assetmaint/src/main/java/org/apache/ofbiz/assetmaint/FixedAssetMaintServices.java
+++ b/assetmaint/src/main/java/org/apache/ofbiz/assetmaint/FixedAssetMaintServices.java
@@ -18,6 +18,7 @@ under the License.
 **/
 package org.apache.ofbiz.assetmaint;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -83,7 +84,7 @@ public class FixedAssetMaintServices {
             EntityConditionList<EntityExpr> ecl = EntityCondition.makeCondition(UtilMisc.toList(
                     EntityCondition.makeCondition("productId", EntityOperator.EQUALS, productId),
                     EntityCondition.makeCondition("facilityId", EntityOperator.EQUALS, facilityId),
-                    EntityCondition.makeCondition("availableToPromiseTotal", EntityOperator.GREATER_THAN, "0")),
+                    EntityCondition.makeCondition("availableToPromiseTotal", EntityOperator.GREATER_THAN, BigDecimal.ZERO)),
                     EntityOperator.AND);
             List<GenericValue> inventoryItems = EntityQuery.use(delegator).from("InventoryItem").where(ecl).queryList();   //&& inventoryItems.size
             // () > 0


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/OFBIZ-13448

## Problem
In `FixedAssetMaintServices.issueInventory`, the InventoryItem lookup builds a condition comparing `availableToPromiseTotal` against the **String** literal `"0"`:

```java
EntityCondition.makeCondition("availableToPromiseTotal", EntityOperator.GREATER_THAN, "0")
```

`InventoryItem.availableToPromiseTotal` is a `fixed-point` field (`java.math.BigDecimal`, `NUMERIC(18,6)`). When the query executes, `SqlJdbcUtil` binds the value by casting it to `java.math.BigDecimal`, so passing a `String` throws a `ClassCastException` (String cannot be cast to BigDecimal). The equivalent EECA (`product/entitydef/eecas.xml`) avoids this by declaring `type="BigDecimal"` on the value; the Java path had no such coercion.

## Fix
Use `BigDecimal.ZERO` instead of the string `"0"`, and add the `java.math.BigDecimal` import.

## Verification
- `./gradlew compileJava` → BUILD SUCCESSFUL.

This is the same fix proposed on the Jira issue, corrected: the issue text used `BigDecimal.Zero` (does not compile) and omitted the required import.