### PR TITLE
Remove a real test coupling in SprintTests and pin @Order on three flagged classes

### DIFF
--- a/assetmaint/src/test/groovy/org/apache/ofbiz/assetmaint/assetmaint/test/FixedAssetMaintTests.groovy
+++ b/assetmaint/src/test/groovy/org/apache/ofbiz/assetmaint/assetmaint/test/FixedAssetMaintTests.groovy
@@ -22,12 +22,14 @@ import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.testtools.JunitJupiterTest
 import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 
 @JunitJupiterTest
 class FixedAssetMaintTests implements JupiterTestHelper {
 
     @Test
+    @Order(1)
     void testCreateFixedAssetMaintUpdateWorkEffortWithProductMaint() {
         // Test case for service createFixedAssetMaintUpdateWorkEffort with a product Maintenance
         String fixedAssetId = 'DEMO_VEHICLE_01'
@@ -56,6 +58,7 @@ class FixedAssetMaintTests implements JupiterTestHelper {
     }
 
     @Test
+    @Order(2)
     void testCreateFixedAssetMaintUpdateWorkEffortWithoutProductMaint() {
         // Test case for service createFixedAssetMaintUpdateWorkEffort without a product maintenance
         String fixedAssetId = 'DEMO_VEHICLE_01'
@@ -87,6 +90,7 @@ class FixedAssetMaintTests implements JupiterTestHelper {
     }
 
     @Test
+    @Order(3)
     void testUpdateFixedAssetMaintAndWorkEffort() {
         // Test case for service updateFixedAssetMaintAndWorkEffort
         String fixedAssetId = 'DEMO_VEHICLE_01'

--- a/ecommerce/src/test/groovy/org/apache/ofbiz/ecommerce/order/test/OrderNotificationTests.groovy
+++ b/ecommerce/src/test/groovy/org/apache/ofbiz/ecommerce/order/test/OrderNotificationTests.groovy
@@ -21,12 +21,14 @@ package org.apache.ofbiz.ecommerce.order.test
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.testtools.JunitJupiterTest
 import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 
 @JunitJupiterTest
 class OrderNotificationTests implements JupiterTestHelper {
 
     @Test
+    @Order(1)
     void testSendOrderConfirmation() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -39,6 +41,7 @@ class OrderNotificationTests implements JupiterTestHelper {
     }
 
     @Test
+    @Order(2)
     void testSendOrderChangeNotification() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -53,6 +56,7 @@ class OrderNotificationTests implements JupiterTestHelper {
     }
 
     @Test
+    @Order(3)
     void testSendOrderBackorderNotification() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -65,6 +69,7 @@ class OrderNotificationTests implements JupiterTestHelper {
     }
 
     @Test
+    @Order(4)
     void testsendOrderPayRetryNotification() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -77,6 +82,7 @@ class OrderNotificationTests implements JupiterTestHelper {
     }
 
     @Test
+    @Order(5)
     void testsendOrderCompleteNotification() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',

--- a/example/src/test/groovy/org/apache/ofbiz/example/test/jupiter/ExampleJupiterTests.groovy
+++ b/example/src/test/groovy/org/apache/ofbiz/example/test/jupiter/ExampleJupiterTests.groovy
@@ -23,6 +23,7 @@ import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.testtools.JunitJupiterTest
 import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -42,6 +43,7 @@ import org.junit.jupiter.params.provider.CsvSource
 class ExampleJupiterTests implements JupiterTestHelper {
 
     @Test
+    @Order(1)
     void shouldCreateExample() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
         Map<String, Object> result = dispatcher.runSync('createExample', [
@@ -58,6 +60,7 @@ class ExampleJupiterTests implements JupiterTestHelper {
     }
 
     @ParameterizedTest(name = '[{index}] exampleTypeId={0}')
+    @Order(2)
     @CsvSource([
             'CONTRIVED',
             'INSPIRED',
@@ -77,6 +80,7 @@ class ExampleJupiterTests implements JupiterTestHelper {
 
     @Disabled('OFBIZ-XXXXX: sample only - demonstrates a documented, reportable skip; not a real defect')
     @Test
+    @Order(3)
     void shouldUpdateExampleUnderConcurrentLoad() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
         Map<String, Object> result = dispatcher.runSync('updateExample', [exampleId: 'TestExampleUpdate', userLogin: userLogin])

--- a/scrum/src/test/groovy/org/apache/ofbiz/scrum/test/SprintTests.groovy
+++ b/scrum/src/test/groovy/org/apache/ofbiz/scrum/test/SprintTests.groovy
@@ -86,35 +86,18 @@ class SprintTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
-    // Migrated from SprintTests.xml:testAddSprintMember
-    // Ordered after testRemoveSprintMember: assignPartyToWorkEffort's own de-dup check
-    // (WorkEffortServicesScript.groovy's filterByDate() against "today") rejects a second
-    // active assignment for the same (workEffortId, partyId, roleTypeId), so if this ran
-    // first, testRemoveSprintMember's own defensive "assign first" call would silently fail
-    // and the subsequent delete-by-PK would find nothing to remove. Pre-existing bug, not
-    // introduced by this migration - see the design doc addendum.
-    @Test
-    @Order(7)
-    void testAddSprintMember() {
-        Map serviceCtx = [
-                workEffortId: 'DEMO-SPRINT-1',
-                roleTypeId: 'SCRUM_TEAM',
-                statusId: 'PRTYASGN_ASSIGNED',
-                partyId: 'DemoCustomer-1',
-                fromDate: java.sql.Timestamp.valueOf(
-                        '2010-07-30 00:00:00.000'),
-                userLogin: userLogin
-        ]
-        Map serviceResult = dispatcher.runSync(
-                'assignPartyToWorkEffort', serviceCtx)
-        assert ServiceUtil.isSuccess(serviceResult)
-    }
-
-    // Migrated from SprintTests.xml:testRemoveSprintMember
+    // Migrated from SprintTests.xml:testAddSprintMember and testRemoveSprintMember.
+    // Originally two separate @Order-pinned methods that only passed in one specific
+    // order: assignPartyToWorkEffort's own de-dup check (WorkEffortServicesScript.groovy's
+    // filterByDate() against "today") rejects a second active assignment for the same
+    // (workEffortId, partyId, roleTypeId), so testAddSprintMember's assignment had to run
+    // after testRemoveSprintMember's assign-then-remove pair, not before. Merged into one
+    // scenario - add a sprint member, then remove that same member - so the coupling is
+    // gone rather than worked around.
     @Test
     @Order(6)
-    void testRemoveSprintMember() {
-        Map serviceCtx = [
+    void testAddAndRemoveSprintMember() {
+        Map assignCtx = [
                 workEffortId: 'DEMO-SPRINT-1',
                 roleTypeId: 'SCRUM_TEAM',
                 statusId: 'PRTYASGN_ASSIGNED',
@@ -122,8 +105,8 @@ class SprintTests implements JupiterTestHelper {
                 fromDate: java.sql.Timestamp.valueOf('2010-07-31 00:00:00.000'),
                 userLogin: userLogin
         ]
-        // Assign first so we can safely remove it regardless of test execution order
-        dispatcher.runSync('assignPartyToWorkEffort', serviceCtx)
+        Map assignResult = dispatcher.runSync('assignPartyToWorkEffort', assignCtx)
+        assert ServiceUtil.isSuccess(assignResult)
 
         Map removeCtx = [
                 workEffortId: 'DEMO-SPRINT-1',
@@ -132,9 +115,9 @@ class SprintTests implements JupiterTestHelper {
                 fromDate: java.sql.Timestamp.valueOf('2010-07-31 00:00:00.000'),
                 userLogin: userLogin
         ]
-        Map serviceResult = dispatcher.runSync(
+        Map removeResult = dispatcher.runSync(
                 'unassignPartyFromWorkEffort', removeCtx)
-        assert ServiceUtil.isSuccess(serviceResult)
+        assert ServiceUtil.isSuccess(removeResult)
     }
 
     /**


### PR DESCRIPTION
Remove a real test coupling in SprintTests and pin @Order on three flagged classes

testAddSprintMember and testRemoveSprintMember (scrum's SprintTests) were two
separately @Order-pinned methods that only passed in one specific order -
assignPartyToWorkEffort's de-dup check rejects a second active assignment
for the same (workEffortId, partyId, roleTypeId), so testAddSprintMember's
assignment had to run after testRemoveSprintMember's own assign-then-remove
pair, not before. Merged the two into one scenario - add a sprint member,
then remove that same member - so the coupling is actually removed instead
of pinned in the one @Order that happened to avoid tripping it.

OrderNotificationTests, ExampleJupiterTests, and FixedAssetMaintTests each
had more than one test method and no @Order at all, flagged by the new
flagUnorderedJupiterTests task on the framework side. Checked each for
inter-test coupling first - none found, every method sets up and asserts on
its own data - so this just pins the existing declaration order with
@Order, same convention as SprintTests. No behavior change.

Verified: testIntegration component=scrum suitename=scrumtests, and the
ecommercetests/example-tests/assetmainttests suites (covering all three
newly-@Order'd classes), all pass with 0 errors/0 failures; codenarcTest
clean.
