### PR TITLE
Fixed: Administrator profile on ecommerce shows FTL error (OFBIZ-13475)

### DIFF
--- a/ecommerce/minilang/customer/CustomerEvents.xml
+++ b/ecommerce/minilang/customer/CustomerEvents.xml
@@ -556,7 +556,7 @@ under the License.
                 <process field="gender"><copy/></process>
 
                 <process field="residenceStatusEnumId"><copy/></process>
-                <process field="maritalStatusEnumId"><copy/></process>
+                <process field="maritalStatusTypeId"><copy/></process>
                 <process field="employmentStatusEnumId"><copy/></process>
                 <process field="occupation"><copy/></process>
                 <process field="yearsWithEmployer"><convert type="Long"><fail-property resource="EcommerceUiLabels" property="EcommerceYearsWithEmployeeNotValid"/></convert></process>

--- a/ecommerce/template/customer/EditPerson.ftl
+++ b/ecommerce/template/customer/EditPerson.ftl
@@ -80,10 +80,11 @@ under the License.
           </div>
           <div class="col-sm-6">
             <label>${uiLabelMap.PartyMaritalStatus}</label>
-            <#assign maritalStatusEnums = EntityQuery.use(delegator).from("Enumeration").where("enumTypeId", "MARITAL_STATUS").cache().orderBy("sequenceId").queryList()!>
-            <select name="maritalStatusEnumId" class="form-control custom-select">
-              <#list maritalStatusEnums as maritalStatus>
-                <option <#if maritalStatus.enumId == personData.maritalStatusEnumId!>selected="selected"</#if> value="${maritalStatus.enumId!}">${maritalStatus.description!}</option>
+            <#assign maritalStatusTypes = EntityQuery.use(delegator).from("MaritalStatusType").cache().queryList()!>
+            <select name="maritalStatusTypeId" class="form-control custom-select">
+              <option value="">${uiLabelMap.CommonSelectOne}</option>
+              <#list maritalStatusTypes as maritalStatusType>
+                <option <#if maritalStatusType.maritalStatusTypeId == personData.maritalStatusTypeId!>selected="selected"</#if> value="${maritalStatusType.maritalStatusTypeId!}">${maritalStatusType.description!}</option>
               </#list>
             </select>
           </div>

--- a/ecommerce/template/customer/ViewProfile.ftl
+++ b/ecommerce/template/customer/ViewProfile.ftl
@@ -89,10 +89,10 @@ under the License.
             <dt class="col-lg-2">${uiLabelMap.PartyWeight}</dt>
             <dd class="col-lg-10">${person.weight}</dd>
           </#if>
-          <#if person.maritalStatusEnumId?has_content>
-            <#assign maritalStatus = EntityQuery.use(delegator).from("Enumeration").where("enumId", person.maritalStatusEnumId!).cache().queryOne()!>
+          <#if person.maritalStatusTypeId?has_content>
+            <#assign maritalStatus = EntityQuery.use(delegator).from("MaritalStatusType").where("maritalStatusTypeId", person.maritalStatusTypeId!).cache().queryOne()!>
             <dt class="col-lg-2">${uiLabelMap.PartyMaritalStatus}</dt>
-            <dd class="col-lg-10">${maritalStatus.description!person.maritalStatusEnumId}</dd>
+            <dd class="col-lg-10">${maritalStatus.description!person.maritalStatusTypeId}</dd>
           </#if>
         </dl>
         </div>


### PR DESCRIPTION
### Description
When logged in using the admin user on the Ecommerce homepage, the viewprofile screen throws an FTL error because of the deprecated `maritalStatusEnumId` field on the `Person` entity (which was deprecated in OFBIZ-13329 and replaced with `maritalStatusTypeId`).

### Changes
- Updated `ViewProfile.ftl` to use `person.maritalStatusTypeId` and query entity `MaritalStatusType`.
- Updated `EditPerson.ftl` to query `MaritalStatusType` and name the select element `maritalStatusTypeId`.
- Updated `CustomerEvents.xml` map processor to process `maritalStatusTypeId`.