### PR TITLE
Add a @MethodSource @ParameterizedTest example to ExampleJupiterTests

### DIFF
--- a/example/src/test/groovy/org/apache/ofbiz/example/test/jupiter/ExampleJupiterTests.groovy
+++ b/example/src/test/groovy/org/apache/ofbiz/example/test/jupiter/ExampleJupiterTests.groovy
@@ -20,13 +20,17 @@ package org.apache.ofbiz.example.test.jupiter
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
+import org.apache.ofbiz.service.ServiceValidationException
 import org.apache.ofbiz.testtools.JunitJupiterTest
 import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 
 /**
  * Jupiter test-cases run through testdef's jupiter-test-suite element (see plugins/example/testdef/tests.xml),
@@ -36,8 +40,10 @@ import org.junit.jupiter.params.provider.CsvSource
  * exposes them as bare delegator/dispatcher (backed by JupiterTestHelper's getDelegator()/getDispatcher()),
  * so call sites read exactly like the old field-injection style - delegator.findOne(...), dispatcher.runSync(...).
  *
- * <p>Demonstrates a {@code @ParameterizedTest} with real CSV-driven invocations, and a
- * {@code @Disabled} test that shows up as a logged, reportable skip instead of silently disappearing.
+ * <p>Demonstrates a {@code @ParameterizedTest} with real CSV-driven invocations, a
+ * {@code @MethodSource}-driven table with multiple typed columns (including an expected-failure
+ * row), and a {@code @Disabled} test that shows up as a logged, reportable skip instead of
+ * silently disappearing.
  */
 @JunitJupiterTest
 class ExampleJupiterTests implements JupiterTestHelper {
@@ -85,6 +91,46 @@ class ExampleJupiterTests implements JupiterTestHelper {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
         Map<String, Object> result = dispatcher.runSync('updateExample', [exampleId: 'TestExampleUpdate', userLogin: userLogin])
         assert ServiceUtil.isSuccess(result)
+    }
+
+    @ParameterizedTest(name = '[{index}] {0}')
+    @Order(4)
+    @MethodSource('exampleCreationCases')
+    void shouldCreateExampleAcrossTypesAndStatuses(String label, String exampleTypeId, String statusId,
+            String exampleName, boolean expectSuccess) {
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
+        Map<String, Object> serviceCtx = [
+                exampleTypeId: exampleTypeId,
+                statusId: statusId,
+                exampleName: exampleName,
+                userLogin: userLogin
+        ]
+        if (expectSuccess) {
+            Map<String, Object> result = dispatcher.runSync('createExample', serviceCtx)
+            assert ServiceUtil.isSuccess(result) : label
+            GenericValue example = from('Example').where('exampleId', result.exampleId).queryOne()
+            assert example != null
+            assert example.exampleTypeId == exampleTypeId
+            assert example.statusId == statusId
+        } else {
+            // A required attribute missing (exampleTypeId/exampleName) fails validation before the
+            // service body runs, so runSync throws instead of returning an error result map.
+            Assertions.assertThrows(ServiceValidationException) {
+                dispatcher.runSync('createExample', serviceCtx)
+            }
+        }
+    }
+
+    @SuppressWarnings('UnusedPrivateMethod')
+    private static List<Arguments> exampleCreationCases() {
+        [
+                Arguments.of('real-world-in-design', 'REAL_WORLD', 'EXST_IN_DESIGN', 'Test Example - Real World', true),
+                Arguments.of('made-up-defined', 'MADE_UP', 'EXST_DEFINED', 'Test Example - Made Up', true),
+                Arguments.of('contrived-approved', 'CONTRIVED', 'EXST_APPROVED', 'Test Example - Contrived', true),
+                Arguments.of('inspired-implemented', 'INSPIRED', 'EXST_IMPLEMENTED', 'Test Example - Inspired', true),
+                Arguments.of('missing-example-type-fails', null, 'EXST_IN_DESIGN', 'Test Example - Missing Type', false),
+                Arguments.of('missing-example-name-fails', 'REAL_WORLD', 'EXST_IN_DESIGN', null, false),
+        ]
     }
 
 }


### PR DESCRIPTION
Demonstrates a multi-column, table-driven parameterized test alongside the existing single-column @CsvSource example, covering both a success path across the Example component's valid types/statuses and a failure path via missing required service parameters.
