### PR TITLE
Retry Lucene index writer lock acquisition instead of dropping the document

### DIFF
--- a/lucene/src/main/java/org/apache/ofbiz/content/search/DocumentIndexer.java
+++ b/lucene/src/main/java/org/apache/ofbiz/content/search/DocumentIndexer.java
@@ -47,6 +47,8 @@ public final class DocumentIndexer extends Thread {
     private Directory indexDirectory;
     // TODO: Move to property file
     private static final int UNCOMMITTED_DOC_LIMIT = 100;
+    private static final int MAX_LOCK_RETRIES = 5;
+    private static final long LOCK_RETRY_DELAY_MILLIS = 500;
 
     private DocumentIndexer(Delegator delegator, String indexName) {
         this.delegator = delegator;
@@ -90,19 +92,33 @@ public final class DocumentIndexer extends Thread {
                 Term documentIdentifier = ofbizDocument.getDocumentIdentifier();
                 Document document = ofbizDocument.prepareDocument(this.delegator);
                 if (indexWriter == null) {
-                    try {
-                        StandardAnalyzer analyzer = new StandardAnalyzer();
-                        indexWriter = new IndexWriter(this.indexDirectory, new IndexWriterConfig(analyzer));
-                    } catch (CorruptIndexException e) {
-                        Debug.logError("Corrupted lucene index: " + e.getMessage(), MODULE);
-                        break;
-                    } catch (LockObtainFailedException e) {
-                        Debug.logError("Could not obtain Lock on lucene index " + e.getMessage(), MODULE);
-                        // TODO: put the thread to sleep waiting for the locked to be released
-                        break;
-                    } catch (IOException e) {
-                        Debug.logError(e.getMessage(), MODULE);
-                        break;
+                    int lockRetries = 0;
+                    while (indexWriter == null) {
+                        try {
+                            StandardAnalyzer analyzer = new StandardAnalyzer();
+                            indexWriter = new IndexWriter(this.indexDirectory, new IndexWriterConfig(analyzer));
+                        } catch (CorruptIndexException e) {
+                            Debug.logError("Corrupted lucene index: " + e.getMessage(), MODULE);
+                            return;
+                        } catch (LockObtainFailedException e) {
+                            lockRetries++;
+                            if (lockRetries > MAX_LOCK_RETRIES) {
+                                Debug.logError("Could not obtain Lock on lucene index after " + MAX_LOCK_RETRIES
+                                        + " retries, giving up: " + e.getMessage(), MODULE);
+                                return;
+                            }
+                            Debug.logWarning("Could not obtain Lock on lucene index, retrying in "
+                                    + LOCK_RETRY_DELAY_MILLIS + "ms: " + e.getMessage(), MODULE);
+                            try {
+                                Thread.sleep(LOCK_RETRY_DELAY_MILLIS);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                return;
+                            }
+                        } catch (IOException e) {
+                            Debug.logError(e.getMessage(), MODULE);
+                            return;
+                        }
                     }
                 }
                 try {


### PR DESCRIPTION
DocumentIndexer's indexing thread gave up and terminated the moment it failed to obtain the Lucene index write lock, silently dropping the document it had already dequeued. Under concurrent test execution this was observed happening repeatedly against the products index.

Now it retries with a short delay a bounded number of times before giving up, and the in-flight document is still indexed once the lock becomes available instead of being lost.

Verified by re-running testIntegration: build stays successful, no suite regressions, lucenetests still passes.