### PR TITLE
Documented: per-component test.api.enabled gate on runExampleTestSuite

### DIFF
--- a/example/servicedef/services.xml
+++ b/example/servicedef/services.xml
@@ -185,10 +185,13 @@ under the License.
         <description>Kicks off a testdef test-suite run asynchronously, scoped to the example
             component only - see TestRunServices.runScopedTestSuite. Gated by the test.api.enabled
             config flag and the TESTEXEC_ADMIN permission (checked inside the underlying service).
-            componentName is deliberately not an attribute here - the component is fixed, not
-            caller-suppliable. testMethodName optionally scopes the run to one
-            @Test/@ParameterizedTest method within the class testCaseName resolves to - requires
-            testCaseName, and only applies when it resolves to a jupiter-test-suite.</description>
+            Also gated by the per-component test.api.enabled.example override - same
+            SystemProperty-backed mechanism, defaults to enabled, lets this component's endpoint be
+            disabled independently of every other component's. componentName is deliberately not an
+            attribute here - the component is fixed, not caller-suppliable. testMethodName optionally
+            scopes the run to one @Test/@ParameterizedTest method within the class testCaseName
+            resolves to - requires testCaseName, and only applies when it resolves to a
+            jupiter-test-suite.</description>
         <attribute name="suiteName" type="String" mode="IN" optional="false"/>
         <attribute name="testCaseName" type="String" mode="IN" optional="true"/>
         <attribute name="testMethodName" type="String" mode="IN" optional="true"/>

--- a/example/src/test/groovy/org/apache/ofbiz/example/test/ExampleJupiterTests.groovy
+++ b/example/src/test/groovy/org/apache/ofbiz/example/test/ExampleJupiterTests.groovy
@@ -51,7 +51,6 @@ class ExampleJupiterTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void shouldCreateExample() {
-
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
 
         String exampleTypeId = testParams.exampleTypeId ?: 'CONTRIVED'
@@ -76,7 +75,6 @@ class ExampleJupiterTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void shouldUpdateExample() {
-
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
 
         String exampleTypeId = testParams.exampleTypeId ?: 'CONTRIVED'
@@ -140,7 +138,6 @@ class ExampleJupiterTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void shouldDeleteExample() {
-
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'system'], false)
 
         String exampleTypeId = testParams.exampleTypeId ?: 'CONTRIVED'


### PR DESCRIPTION
Documented: per-component test.api.enabled.example gate on runExampleTestSuite
Fixed: CodeNarc BlockStartsWithBlankLine violations in ExampleJupiterTests

(OFBIZ-)

Explanation
Companion to the ofbiz-trunk PR adding a per-component override of the REST-triggered
test-run API's global test.api.enabled flag (new property:
test.api.enabled.<componentName>). No behavior change to anything in this repo -
runExampleTestSuite already inherits the new gate automatically through
TestRunServices.runScopedTestSuite, with zero code change needed. This PR only updates
its service description, which previously mentioned the global test.api.enabled flag and
the TESTEXEC_ADMIN permission but not the per-component override - even though
runExampleTestSuite is the exact service that override gates in practice, since it's
permanently scoped to the example component.

Also fixes 3 pre-existing CodeNarc BlockStartsWithBlankLine violations in
ExampleJupiterTests (each test method opened with a blank line right after its brace),
unrelated to the above but found while working on this branch.

Thanks:
