### PR TITLE
Added: screenxlsx demo view-maps and UI links for the example plugin (OFBIZ-13567)

### DIFF
--- a/example/webapp/example/WEB-INF/controller.xml
+++ b/example/webapp/example/WEB-INF/controller.xml
@@ -52,6 +52,8 @@ under the License.
     <request-map uri="ExampleReportXls"><security https="true" auth="true"/><response name="success" type="view" value="ExampleReportXls"/></request-map>
     <request-map uri="ExampleReportPdf"><security https="true" auth="true"/><response name="success" type="view" value="ExampleReportPdf"/></request-map>
     <request-map uri="ListExampleExport"><security https="true" auth="true"/><response name="success" type="view" value="ListExampleExport"/></request-map>
+    <request-map uri="ListExampleExportXlsx"><security https="true" auth="true"/><response name="success" type="view" value="ListExampleExportXlsx"/></request-map>
+    <request-map uri="ExampleReportXlsx"><security https="true" auth="true"/><response name="success" type="view" value="ExampleReportXlsx"/></request-map>
     <request-map uri="createExample">
         <security https="true" auth="true"/>
         <event type="service" invoke="createExample"/>
@@ -266,8 +268,10 @@ under the License.
     <view-map name="EditExampleItems" type="screen" page="component://example/widget/example/ExampleScreens.xml#EditExampleItems"/>
     <view-map name="EditExampleFeatureAppls" type="screen" page="component://example/widget/example/ExampleScreens.xml#EditExampleFeatureAppls"/>
     <view-map name="ListExampleExport" type="screenxls" page="component://example/widget/example/ExampleScreens.xml#ListExampleExport" content-type="application/vnd.ms-excel"/>
+    <view-map name="ListExampleExportXlsx" type="screenxlsx" page="component://example/widget/example/ExampleScreens.xml#ListExampleExport" content-type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
     <view-map name="ExampleReportHtml" type="screen" page="component://example/widget/example/ExampleScreens.xml#ExampleReport"/>
     <view-map name="ExampleReportXls" type="screenxls" page="component://example/widget/example/ExampleScreens.xml#ExampleReport" content-type="application/vnd.ms-excel"/>
+    <view-map name="ExampleReportXlsx" type="screenxlsx" page="component://example/widget/example/ExampleScreens.xml#ExampleReport" content-type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
     <view-map name="ExampleReportPdf" type="screenfop" page="component://example/widget/example/ExampleScreens.xml#ExampleReport" content-type="application/pdf" encoding="none"/>
     <view-map name="ExampleReportPdfBarcode" type="screenfop" page="component://example/widget/example/ExampleScreens.xml#ExampleReportPdfBarcode" content-type="application/pdf" encoding="none"/>
 

--- a/example/widget/example/CommonScreens.xml
+++ b/example/widget/example/CommonScreens.xml
@@ -146,6 +146,9 @@ under the License.
                                             <link target="ExampleReportXls" text="${uiLabelMap.CommonViewAsXls}" style="buttontext">
                                                 <parameter param-name="exampleId"/>
                                             </link>
+                                            <link target="ExampleReportXlsx" text="${uiLabelMap.CommonViewAsXlsx}" style="buttontext">
+                                                <parameter param-name="exampleId"/>
+                                            </link>
                                             <link target="ExampleReportPdf" text="${uiLabelMap.CommonPdf}" style="buttontext" target-window="_blank">
                                                 <parameter param-name="exampleId"/>
                                                 <image url-mode="raw" src="${iconsLocation}/page_white_acrobat.png"/>

--- a/example/widget/example/ExampleForms.xml
+++ b/example/widget/example/ExampleForms.xml
@@ -52,6 +52,10 @@ under the License.
             <hyperlink also-hidden="false" target-type="plain" description="${uiLabelMap.CommonExport}"
                        target="javascript: document.FindExamples.action='ListExampleExport'; document.FindExamples.submit();"/>
         </field>
+        <field name="exportButtonXlsx" position="2" widget-style="smallSubmit" title=" ">
+            <hyperlink also-hidden="false" target-type="plain" description="${uiLabelMap.CommonViewAsXlsx}"
+                       target="javascript: document.FindExamples.action='ListExampleExportXlsx'; document.FindExamples.submit();"/>
+        </field>
     </form>
 
     <grid name="ListExamples" list-name="listIt" paginate-target="FindExample" default-entity-name="Example" separate-columns="true"


### PR DESCRIPTION
Adds demo view-maps pointing the example plugin's existing screens at the new screenxlsx view-handler type from ofbiz-framework, alongside their existing screenxls-based counterparts.

- ListExampleExportXlsx and ExampleReportXlsx view-maps point at the existing ListExampleExport and ExampleReport screens
- Matching UI entry points: a "View as spreadsheet (.xlsx)" button-bar link next to ExampleReportXls's, and a matching export button on the ListExampleExport search form next to its existing Export button
- Depends on the companion ofbiz-framework PR